### PR TITLE
sort order: fix monthly label

### DIFF
--- a/src/components/search/sort-order.js
+++ b/src/components/search/sort-order.js
@@ -21,7 +21,7 @@ export const getSortOrderOptions = () => {
     },
     {
       id: 'monthly',
-      label: 'By stars added the last 30 months'
+      label: 'By stars added the last month'
     },
     {
       id: 'yearly',


### PR DESCRIPTION
fix the monthly label from `last 30 months` to `last month`

I'm not sure if this should be `last 30 days`