### PR TITLE
Update about page links styling

### DIFF
--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useSelector } from 'containers/project-data-container'
 import { StaticContentContainer } from 'containers/static-content-container'
 import { CreateIssueLink } from 'components/user-requests/add-project/create-issue-link'
-import { Card, MainContent, PageHeader } from 'components/core'
+import { Card, ExternalLink, MainContent, PageHeader } from 'components/core'
 import 'stylesheets/markdown-body.css'
 
 const AboutPage = () => {
@@ -82,8 +82,8 @@ const AboutPage = () => {
         <h2>Show your support!</h2>
         <p>
           If you find the application useful, you can star the project's
-          repository on <a href={repoURL}>GitHub</a> or{' '}
-          <a href={sponsorURL}>become a sponsor</a>.
+          repository on <ExternalLink url={repoURL}>GitHub</ExternalLink> or{' '}
+          <ExternalLink url={sponsorURL}>become a sponsor</ExternalLink>.
         </p>
         <p>
           We are all made of stars{' '}


### PR DESCRIPTION
## Goal

I noticed the links in the about page are not styled differently from the text. Now they are.

## How to test

Check out the about page :) 

## Screenshots

![Screenshot from 2021-09-28 11-37-30](https://user-images.githubusercontent.com/7598058/135008226-fa86ac03-543d-439b-8664-681c49b0193f.png)
