### PR TITLE
Generate custom project slug to allow `$` in URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "react-use": "^15.3.0",
         "react-vertical-timeline-component": "^3.0.2",
         "reselect": "^4.0.0",
-        "slugify": "^1.3.4",
         "swr": "^0.2.3",
         "tinytime": "^0.2.6",
         "typescript": "^4.1.6",
@@ -5142,20 +5141,88 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
-      "dev": true,
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
       "dependencies": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8.3"
+      }
+    },
+    "node_modules/@types/jest/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/diff-sequences": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+      "engines": {
+        "node": ">= 8.3"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+      "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "diff-sequences": "^25.2.6",
+        "jest-get-type": "^25.2.6",
+        "pretty-format": "^25.5.0"
+      },
+      "engines": {
+        "node": ">= 8.3"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-get-type": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+      "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+      "engines": {
+        "node": ">= 8.3"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+      "dependencies": {
+        "@jest/types": "^25.5.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      },
+      "engines": {
+        "node": ">= 8.3"
       }
     },
     "node_modules/@types/js-cookie": {
@@ -19498,14 +19565,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/slugify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
-      "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -27529,20 +27588,72 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
     },
     "@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
-      "dev": true,
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
       "requires": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "@types/js-cookie": {
@@ -39465,11 +39576,6 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
-    },
-    "slugify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
-      "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bestofjs-webui",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Best of JS front-end web application",
   "engines": {
     "node": "14.x"
@@ -55,7 +55,6 @@
     "react-use": "^15.3.0",
     "react-vertical-timeline-component": "^3.0.2",
     "reselect": "^4.0.0",
-    "slugify": "^1.3.4",
     "swr": "^0.2.3",
     "tinytime": "^0.2.6",
     "typescript": "^4.1.6",

--- a/src/components/core/project-utils.test.ts
+++ b/src/components/core/project-utils.test.ts
@@ -1,0 +1,13 @@
+import { slugify } from "./project";
+
+it("Should generate the right slug", () => {
+  expect(slugify("Vue.js")).toEqual("vuejs");
+  expect(slugify("React Native")).toEqual("react-native");
+  expect(slugify("date-fns")).toEqual("date-fns");
+  expect(slugify("Angular 1")).toEqual("angular-1");
+  expect(slugify("$mol")).toEqual("$mol");
+  expect(slugify("You don't know JS")).toEqual("you-dont-know-js");
+  expect(slugify("JS Algorithms & Data Structures")).toEqual(
+    "js-algorithms-and-data-structures"
+  );
+});

--- a/src/components/core/project.tsx
+++ b/src/components/core/project.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import numeral from "numeral";
-import slugify from "slugify";
 
 import { Box, Center } from "components/core";
 import { StarIcon } from "./icons";
@@ -85,8 +84,27 @@ function formatBigNumber(value: number): string {
 }
 
 export function getProjectId(project: BestOfJS.Project) {
-  return slugify(project.name, { lower: true, remove: /[.'/]/g });
+  return slugify(project.name);
 }
+
+export function slugify(source: string) {
+  return source
+    .trim()
+    .replace(/\W/g, replaceSpecialChar)
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+function replaceSpecialChar(char: string) {
+  return charMap.has(char) ? (charMap.get(char) as string) : "-";
+}
+
+const charMap = new Map([
+  [".", ""],
+  ["'", ""],
+  ["&", "and"],
+  ["$", "$"], // keep `$` characters (for `$mol` project)
+]);
 
 export const getDeltaByDay =
   (period: string) =>


### PR DESCRIPTION
## Goal

Generate the project slug (used in project details page URL `/projects/:slug`) by ourselves instead of relying on `slugify` NPM package.

We should allow the "$" symbol in project slugs as requested by @nin-jin here: https://github.com/michaelrambeau/bestofjs/issues/451#issuecomment-1017255754

## How to test

Unit tests were added to ensure the slugs are correctly generated.



