### PR TITLE
Fix image background color inside README.md sections

### DIFF
--- a/src/components/core/icons.tsx
+++ b/src/components/core/icons.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GoChevronDown, GoLinkExternal, GoTag } from "react-icons/go";
+import { GoChevronDown, GoTag } from "react-icons/go";
 import { MdStarBorder } from "react-icons/md";
 
 import { Icon, IconProps } from "components/core";
@@ -65,8 +65,22 @@ const SVGContainer = ({ children, color = "currentColor", size = 24 }) => {
   );
 };
 
+// Stealing the icon from https://chakra-ui.com/docs/media-and-icons/icon#all-icons
 export const ExternalLinkIcon = (props: IconProps) => {
-  return <Icon as={GoLinkExternal} ml={1} {...props} />;
+  return (
+    <Icon viewBox="0 0 24 24" ml={1} {...props}>
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="2"
+      >
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+        <path d="M15 3h6v6"></path>
+        <path d="M10 14L21 3"></path>
+      </g>
+    </Icon>
+  );
 };
 
 export const DiscordIcon = ({ size = 24 }) => {

--- a/src/components/core/layout.tsx
+++ b/src/components/core/layout.tsx
@@ -7,6 +7,7 @@ import {
 } from "@chakra-ui/react";
 
 export {
+  Badge,
   Box,
   Button,
   CloseButton,

--- a/src/components/project-details/github-repo-info.tsx
+++ b/src/components/project-details/github-repo-info.tsx
@@ -36,13 +36,7 @@ export const GitHubRepoInfo = ({ project }: Props) => {
 
   return (
     <Card>
-      <HStack
-        alignItems="center"
-        py={2}
-        px={4}
-        borderBottomWidth="1px"
-        backgroundX="linear-gradient(120deg, var(--chakra-colors-orange-100) 5%, transparent 5% 95%)"
-      >
+      <HStack alignItems="center" py={2} px={4} borderBottomWidth="1px">
         <Icon as={GoMarkGithub} fontSize="32px" className="icon" />
         <Box mr={2}>GitHub</Box>
         <StarTotal value={stars} />

--- a/src/components/project-details/github-repo-info.tsx
+++ b/src/components/project-details/github-repo-info.tsx
@@ -8,7 +8,7 @@ import {
   Card,
   CardBody,
   CardSection,
-  ExternalLink,
+  Link,
   Box,
   Flex,
   Icon,
@@ -44,12 +44,16 @@ export const GitHubRepoInfo = ({ project }: Props) => {
       <CardBody>
         <CardSection>
           <SimpleGrid gap={4} templateColumns={{ sm: "1fr", md: "1fr 1fr" }}>
-            <Box>
-              <ExternalLink url={repository}>
-                {full_name}
-                <ExternalLinkIcon />
-              </ExternalLink>
-            </Box>
+            <Link
+              url={repository}
+              isExternal
+              display="flex"
+              alignItems="center"
+              fontFamily="button"
+            >
+              {full_name}
+              <ExternalLinkIcon />
+            </Link>
             <Box>
               {created_at && (
                 <>

--- a/src/components/project-details/npm-card/index.tsx
+++ b/src/components/project-details/npm-card/index.tsx
@@ -2,13 +2,15 @@ import React from "react";
 import { IoLogoNpm } from "react-icons/io";
 
 import {
+  Badge,
   Box,
   Card,
   CardBody,
+  CardSection,
+  Flex,
   HStack,
   Icon,
-  CardSection,
-  ExternalLink,
+  Link,
   Spinner,
 } from "components/core";
 import { ExternalLinkIcon } from "components/core/icons";
@@ -53,12 +55,19 @@ const CardBodyContent = ({ project, isLoading, error }) => {
   return (
     <>
       <CardSection>
-        <p>
-          <ExternalLink url={`https://www.npmjs.com/package/${packageName}`}>
-            {packageName} {npm.version}
+        <Flex alignItems="center">
+          <Link
+            url={`https://www.npmjs.com/package/${packageName}`}
+            isExternal
+            fontFamily="button"
+          >
+            {packageName}
             <ExternalLinkIcon />
-          </ExternalLink>
-        </p>
+          </Link>
+          <Badge fontSize="1rem" ml={2}>
+            {npm.version}
+          </Badge>
+        </Flex>
       </CardSection>
       <CardSection>
         <PackageMonthlyDownloadChart project={project} />

--- a/src/components/project-details/npm-card/index.tsx
+++ b/src/components/project-details/npm-card/index.tsx
@@ -25,13 +25,7 @@ type Props = {
 export const NpmCard = (props: Props) => {
   return (
     <Card style={{ marginTop: "2rem" }}>
-      <HStack
-        alignItems="center"
-        py={1}
-        px={4}
-        borderBottomWidth="1px"
-        backgroundX="linear-gradient(120deg, var(--chakra-colors-red-100) 5%, transparent 5% 95%)"
-      >
+      <HStack alignItems="center" py={1} px={4} borderBottomWidth="1px">
         <Icon
           as={IoLogoNpm}
           className="icon"

--- a/src/stylesheets/markdown-body.css
+++ b/src/stylesheets/markdown-body.css
@@ -778,7 +778,6 @@
 .markdown-body img {
   max-width: 100%;
   box-sizing: initial;
-  background-color: #fff;
 }
 
 .markdown-body img[align="right"] {
@@ -1137,9 +1136,6 @@
 .chakra-ui-dark .markdown-body table tr:nth-child(2n) {
   background-color: var(--backgroundColor);
 }
-.chakra-ui-dark .markdown-body img {
-  background-color: #0d1117;
-}
 .chakra-ui-dark .markdown-body code {
   background-color: rgba(240, 246, 252, 0.15);
 }
@@ -1158,4 +1154,16 @@
 }
 .chakra-ui-dark .markdown-body .blob-code-inner {
   color: #c9d1d9;
+}
+
+/* 
+Images can target light/dark modes
+https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/ 
+E.g. TailwindCSS
+*/
+.chakra-ui-light .markdown-body [href$="#gh-dark-mode-only"] {
+  display: none;
+}
+.chakra-ui-dark .markdown-body [href$="#gh-light-mode-only"] {
+  display: none;
 }


### PR DESCRIPTION
## Goal

- Fix background color applied to images included in the README.md section #127 
- Handle [Specify theme context for images in Markdown](https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/) feature
 
This theme context feature is used by some projects like TailwindCSS: 

Right now it looks weird because we display both light theme and dark theme logos:

![image](https://user-images.githubusercontent.com/5546996/152710486-0a09d7f1-889f-4212-b994-baf7b7eb529f.png)


## Screenshots

#### TailwindCSS

![image](https://user-images.githubusercontent.com/5546996/152710514-0430b094-24a5-4232-b999-df5a2830f1e8.png)

#### Embla Carousel

![image](https://user-images.githubusercontent.com/5546996/152710558-c4e1d317-f1aa-4160-ad61-ff8445b9be64.png)


