### PR TITLE
Remove unused packages + Remove unused `import React from 'react'`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
         "@headlessui/react": "^1.4.0",
         "cross-env": "^7.0.3",
         "framer-motion": "^4.1.17",
-        "lodash": "^4.17.21",
-        "lodash.times": "^4.3.2",
         "numeral": "^1.5.3",
         "qs": "^6.9.0",
         "react": "^17.0.2",
@@ -51,9 +49,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^0.14.3",
         "prettier": "^2.4.1",
-        "pretty-quick": "^1.4.1",
-        "react-testing-library": "^4.1.2",
-        "ts-jest": "^26.1.2"
+        "pretty-quick": "^1.4.1"
       },
       "engines": {
         "node": "14.x"
@@ -3692,12 +3688,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
-    "node_modules/@sheerun/mutationobserver-shim": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
-      "dev": true
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -3991,16 +3981,6 @@
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
       }
     },
     "node_modules/@types/jest": {
@@ -5814,18 +5794,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
-      }
-    },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -7763,95 +7731,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
-    },
-    "node_modules/dom-testing-library": {
-      "version": "3.19.4",
-      "resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-3.19.4.tgz",
-      "integrity": "sha512-GJOx8CLpnkvM3takILOsld/itUUc9+7Qh6caN1Spj6+9jIgNPY36fsvoH7sEgYokC0lBRdttO7G7fIFYCXlmcA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.3",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "pretty-format": "^24.7.0",
-        "wait-for-expect": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dom-testing-library/node_modules/@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/dom-testing-library/node_modules/@types/yargs": {
-      "version": "13.0.9",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
-      "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/dom-testing-library/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/dom-testing-library/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dom-testing-library/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/dom-testing-library/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/dom-testing-library/node_modules/pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
@@ -12773,11 +12652,6 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
-    "node_modules/lodash.times": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.times/-/lodash.times-4.3.2.tgz",
-      "integrity": "sha1-Ph8lZcQxdU1Uq1fy7RdBk5KFyh0="
-    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -12861,12 +12735,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -16762,19 +16630,6 @@
         }
       }
     },
-    "node_modules/react-testing-library": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-4.1.9.tgz",
-      "integrity": "sha512-RBttOeFQg/p+PRc7CTcTxI9fmRwed8q6rdU1gaforp2hB899X0M6hL4vBfjJ8Vmova6juM9jTuR5x6/wbqOv9g==",
-      "dev": true,
-      "dependencies": {
-        "dom-testing-library": "^3.1.0",
-        "wait-for-expect": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/react-toggled": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/react-toggled/-/react-toggled-1.2.7.tgz",
@@ -19881,54 +19736,6 @@
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
-    "node_modules/ts-jest": {
-      "version": "26.1.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.1.4.tgz",
-      "integrity": "sha512-Nd7diUX6NZWfWq6FYyvcIPR/c7GbEF75fH1R6coOp3fbNzbRJBZZAn0ueVS0r8r9ral1VcrpneAFAwB3TsVS1Q==",
-      "dev": true,
-      "dependencies": {
-        "bs-logger": "0.x",
-        "buffer-from": "1.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "26.x",
-        "json5": "2.x",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "mkdirp": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "18.x"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/ts-jest/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -20515,12 +20322,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/wait-for-expect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
-      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==",
-      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -25066,12 +24867,6 @@
         }
       }
     },
-    "@sheerun/mutationobserver-shim": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -25319,16 +25114,6 @@
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
       "requires": {
         "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
       }
     },
     "@types/jest": {
@@ -26790,15 +26575,6 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
-      }
-    },
-    "bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "requires": {
-        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -28348,82 +28124,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
           "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
-        }
-      }
-    },
-    "dom-testing-library": {
-      "version": "3.19.4",
-      "resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-3.19.4.tgz",
-      "integrity": "sha512-GJOx8CLpnkvM3takILOsld/itUUc9+7Qh6caN1Spj6+9jIgNPY36fsvoH7sEgYokC0lBRdttO7G7fIFYCXlmcA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "pretty-format": "^24.7.0",
-        "wait-for-expect": "^1.1.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.9",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
-          "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^24.9.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^3.2.0",
-            "react-is": "^16.8.4"
-          }
         }
       }
     },
@@ -32213,11 +31913,6 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
-    "lodash.times": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.times/-/lodash.times-4.3.2.tgz",
-      "integrity": "sha1-Ph8lZcQxdU1Uq1fy7RdBk5KFyh0="
-    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -32289,12 +31984,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -35414,16 +35103,6 @@
         "tslib": "^1.0.0"
       }
     },
-    "react-testing-library": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-4.1.9.tgz",
-      "integrity": "sha512-RBttOeFQg/p+PRc7CTcTxI9fmRwed8q6rdU1gaforp2hB899X0M6hL4vBfjJ8Vmova6juM9jTuR5x6/wbqOv9g==",
-      "dev": true,
-      "requires": {
-        "dom-testing-library": "^3.1.0",
-        "wait-for-expect": "^1.0.0"
-      }
-    },
     "react-toggled": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/react-toggled/-/react-toggled-1.2.7.tgz",
@@ -37909,38 +37588,6 @@
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
-    "ts-jest": {
-      "version": "26.1.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.1.4.tgz",
-      "integrity": "sha512-Nd7diUX6NZWfWq6FYyvcIPR/c7GbEF75fH1R6coOp3fbNzbRJBZZAn0ueVS0r8r9ral1VcrpneAFAwB3TsVS1Q==",
-      "dev": true,
-      "requires": {
-        "bs-logger": "0.x",
-        "buffer-from": "1.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "26.x",
-        "json5": "2.x",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "mkdirp": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "18.x"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
-        }
-      }
-    },
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -38393,12 +38040,6 @@
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
-    },
-    "wait-for-expect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
-      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==",
-      "dev": true
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "@headlessui/react": "^1.4.0",
     "cross-env": "^7.0.3",
     "framer-motion": "^4.1.17",
-    "lodash": "^4.17.21",
-    "lodash.times": "^4.3.2",
     "numeral": "^1.5.3",
     "qs": "^6.9.0",
     "react": "^17.0.2",
@@ -69,9 +67,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^0.14.3",
     "prettier": "^2.4.1",
-    "pretty-quick": "^1.4.1",
-    "react-testing-library": "^4.1.2",
-    "ts-jest": "^26.1.2"
+    "pretty-quick": "^1.4.1"
   },
   "browserslist": [
     ">0.2%",

--- a/src/app-update-checker.tsx
+++ b/src/app-update-checker.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useLifecycles } from "react-use";
 import { Box, Button, LightMode, Stack, useToast } from "@chakra-ui/react";
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 
 import Routes from "./pages/routes";

--- a/src/components/core/empty-content.js
+++ b/src/components/core/empty-content.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const EmptyContent = ({ children }) => {
   return (
     <div style={{ border: "2px dashed var(--iconColor)", padding: "2rem" }}>

--- a/src/components/core/icons.tsx
+++ b/src/components/core/icons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { GoChevronDown, GoTag } from "react-icons/go";
 import { MdStarBorder } from "react-icons/md";
 

--- a/src/components/core/main-content.js
+++ b/src/components/core/main-content.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const MainContent = (props) => (
   <div id="main-content" className="container" {...props}>
     {props.children}

--- a/src/components/core/pagination/pagination-controls.js
+++ b/src/components/core/pagination/pagination-controls.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Box, HStack, Flex, IconButton } from "components/core";
 
 import {

--- a/src/components/core/project.tsx
+++ b/src/components/core/project.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import numeral from "numeral";
 
 import { Box, Center } from "components/core";

--- a/src/components/core/section.tsx
+++ b/src/components/core/section.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Box, Flex, Heading, chakra } from "./layout";
 
 export const Section = chakra.section;

--- a/src/components/core/spinner.tsx
+++ b/src/components/core/spinner.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BoxProps, Center } from "./layout";
 import styled from "@emotion/styled";
 

--- a/src/components/core/typography.tsx
+++ b/src/components/core/typography.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 
 import { usePageTitle } from "./html-head";

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import styled from "@emotion/styled";
 import { GoMarkGithub } from "react-icons/go";

--- a/src/components/hall-of-fame/card-project-labels.tsx
+++ b/src/components/hall-of-fame/card-project-labels.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 
 import { Button, Wrap, WrapItem } from "components/core";

--- a/src/components/hall-of-fame/hall-of-fame-member-card.tsx
+++ b/src/components/hall-of-fame/hall-of-fame-member-card.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import numeral from "numeral";
 import { GoGlobe, GoPackage } from "react-icons/go";

--- a/src/components/hall-of-fame/hall-of-fame-member-list.tsx
+++ b/src/components/hall-of-fame/hall-of-fame-member-list.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 
 import { HeroCard } from "./hall-of-fame-member-card";

--- a/src/components/hall-of-fame/more-heroes.tsx
+++ b/src/components/hall-of-fame/more-heroes.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { CreateIssueLink } from "components/user-requests/add-project/create-issue-link";
 
 export const MoreHeroes = () => {

--- a/src/components/header/color-mode-picker.tsx
+++ b/src/components/header/color-mode-picker.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MdWbSunny } from "react-icons/md";
 import { IoMdMoon } from "react-icons/io";
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link as RouterLink, NavLink } from "react-router-dom";
 import styled from "@emotion/styled";
 import { GoMarkGithub } from "react-icons/go";

--- a/src/components/header/navigation-dropdown-menu.tsx
+++ b/src/components/header/navigation-dropdown-menu.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { useMedia } from "react-use";
 import { FiMenu } from "react-icons/fi";

--- a/src/components/header/user-dropdown-menu.tsx
+++ b/src/components/header/user-dropdown-menu.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import styled from "@emotion/styled";
 import { GoBookmark, GoSignOut } from "react-icons/go";

--- a/src/components/home/dark-mode-news.tsx
+++ b/src/components/home/dark-mode-news.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { GoMegaphone } from "react-icons/go";
 
 import {

--- a/src/components/home/home-projects.tsx
+++ b/src/components/home/home-projects.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { GoFlame, GoGift } from "react-icons/go";
 

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import numeral from "numeral";
 import { Link as RouterLink } from "react-router-dom";

--- a/src/components/home/progress-bar.tsx
+++ b/src/components/home/progress-bar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 
 export const ProgressBar = ({ progress }) => {

--- a/src/components/home/rising-stars-news.tsx
+++ b/src/components/home/rising-stars-news.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { GoMegaphone } from "react-icons/go";
 
 import {

--- a/src/components/monthly-rankings/rankings.tsx
+++ b/src/components/monthly-rankings/rankings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import { GoChevronLeft, GoChevronRight } from "react-icons/go";
 

--- a/src/components/project-details/github-repo-info.tsx
+++ b/src/components/project-details/github-repo-info.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import numeral from "numeral";
 import styled from "@emotion/styled";
 import { GoMarkGithub, GoGitCommit } from "react-icons/go";

--- a/src/components/project-details/index.tsx
+++ b/src/components/project-details/index.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { GitHubRepoInfo } from "./github-repo-info";
 import { NpmCard } from "./npm-card";
 import { ReadmeCard } from "./readme-card";

--- a/src/components/project-details/monthly-trends-chart.tsx
+++ b/src/components/project-details/monthly-trends-chart.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Box, BoxProps, Flex } from "@chakra-ui/react";
 import numeral from "numeral";
 

--- a/src/components/project-details/npm-card/bundle-size.tsx
+++ b/src/components/project-details/npm-card/bundle-size.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Toggle from "react-toggled";
 
 import { ExpandableSection } from "./expandable-section";

--- a/src/components/project-details/npm-card/dependencies.tsx
+++ b/src/components/project-details/npm-card/dependencies.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Toggle from "react-toggled";
 import { Link as RouterLink } from "react-router-dom";
 import styled from "@emotion/styled";

--- a/src/components/project-details/npm-card/expandable-section.tsx
+++ b/src/components/project-details/npm-card/expandable-section.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import { GoTriangleDown, GoTriangleRight } from "react-icons/go";
 

--- a/src/components/project-details/npm-card/file-size.tsx
+++ b/src/components/project-details/npm-card/file-size.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { prettyBytes } from "helpers/pretty-bytes";
 
 type Props = { value: number };

--- a/src/components/project-details/npm-card/index.tsx
+++ b/src/components/project-details/npm-card/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { IoLogoNpm } from "react-icons/io";
 
 import {

--- a/src/components/project-details/npm-card/monthly-download-chart.tsx
+++ b/src/components/project-details/npm-card/monthly-download-chart.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { MonthlyTrendsChart } from "components/project-details/monthly-trends-chart";
 import { useFetchMonthlyDownloads } from "../../../api/hooks";
 import { Box, Spinner, useColorModeValue } from "../../core";

--- a/src/components/project-details/npm-card/package-size.tsx
+++ b/src/components/project-details/npm-card/package-size.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Toggle from "react-toggled";
 
 import { ExpandableSection } from "./expandable-section";

--- a/src/components/project-details/npm-card/size-details-list.tsx
+++ b/src/components/project-details/npm-card/size-details-list.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 
 const Div = styled.div`

--- a/src/components/project-details/project-header.tsx
+++ b/src/components/project-details/project-header.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import { GoHome, GoMarkGithub } from "react-icons/go";
 import { DiNpm } from "react-icons/di";

--- a/src/components/project-details/readme-card.tsx
+++ b/src/components/project-details/readme-card.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { GoBook } from "react-icons/go";
 
 import {

--- a/src/components/project-list/project-table.tsx
+++ b/src/components/project-list/project-table.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import { Link as RouterLink } from "react-router-dom";
 import numeral from "numeral";

--- a/src/components/search/project-paginated-list.tsx
+++ b/src/components/search/project-paginated-list.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import {
   ProjectScore,
   ProjectTable,

--- a/src/components/search/sort-order-picker.tsx
+++ b/src/components/search/sort-order-picker.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Box, Button } from "components/core";
 import { ChevronDownIcon } from "components/core/icons";
 import { useSearch } from "./search-container";

--- a/src/components/tags/paginated-tag-list.tsx
+++ b/src/components/tags/paginated-tag-list.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 
 import { PaginationContainer } from "components/core/pagination/provider";

--- a/src/components/tags/project-tag.tsx
+++ b/src/components/tags/project-tag.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import { MdAdd } from "react-icons/md";
 

--- a/src/components/tags/tag-list-sort-order.tsx
+++ b/src/components/tags/tag-list-sort-order.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Box, Button } from "components/core";
 import { DropdownMenu, Menu, MenuGroup, MenuItem } from "components/core/menu";
 import { ChevronDownIcon } from "components/core/icons";

--- a/src/components/tags/tag-list.tsx
+++ b/src/components/tags/tag-list.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link as RouterLink, useHistory } from "react-router-dom";
 import styled from "@emotion/styled";
 

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import {
   VerticalTimeline,

--- a/src/components/user-requests/add-project/create-issue-link.tsx
+++ b/src/components/user-requests/add-project/create-issue-link.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { ExternalLink } from "../../core";
 import { ISSUE_TRACKER_URL } from "config";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "react-dom";
 
 import { unregister } from "./registerServiceWorker";

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import {
   Box,
   ExternalLink,

--- a/src/pages/bookmarks-page.tsx
+++ b/src/pages/bookmarks-page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { GoBookmark } from "react-icons/go";
 
 import { useSelector } from "containers/project-data-container";

--- a/src/pages/featured-page.tsx
+++ b/src/pages/featured-page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import { GoStar } from "react-icons/go";
 

--- a/src/pages/hall-of-fame-page.tsx
+++ b/src/pages/hall-of-fame-page.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { useHallOfFame } from "containers/hall-of-fame-container";
 import { MainContent, PageHeader, Spinner } from "components/core";
 import { MoreHeroes } from "components/hall-of-fame/more-heroes";

--- a/src/pages/monthly-rankings-page.tsx
+++ b/src/pages/monthly-rankings-page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { GoCalendar } from "react-icons/go";
 

--- a/src/pages/no-match-page.tsx
+++ b/src/pages/no-match-page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 
 import { MainContent } from "components/core";

--- a/src/pages/project-details-page.tsx
+++ b/src/pages/project-details-page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useParams } from "react-router-dom";
 import { Route, Switch } from "react-router-dom";
 

--- a/src/pages/search-results-page.tsx
+++ b/src/pages/search-results-page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import styled from "@emotion/styled";
 

--- a/src/pages/tags-page.tsx
+++ b/src/pages/tags-page.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { useSelector } from "containers/project-data-container";
 import { getAllTagsSortedBy } from "selectors";
 import { PaginatedTagList } from "components/tags/paginated-tag-list";

--- a/src/pages/timeline-page.tsx
+++ b/src/pages/timeline-page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import styled from "@emotion/styled";
 


### PR DESCRIPTION
## Goal
1. There are some unused packages that are still in the `package.json`. With the help of `npx depcheck`, I see that those following packages are not used:
  - lodash
  - lodash.times
  - react-testing-library
  - ts-jest
  I hope it saves a little bit of time and disk spaces when developing and deploying

2. Remove unused `import React from 'react'` since `bestofjs-webui` use `react@17` with [New JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
## How to test
- Nothing changed. `npm run start` and `npm run build` stills work fine

## Screenshots
(nothing changed)
![image](https://user-images.githubusercontent.com/8603085/169444309-78691989-7fff-475f-a8f4-345315537a84.png)
