### PR TITLE
Make sure timeline page not broken

### DIFF
--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -22,18 +22,20 @@ const template = tinytime("{MMMM} {YYYY}");
 function useTimelineProjects() {
   const projects: BestOfJS.Project[] = useSelector(
     findProjectsByIds(featuredProjects.map(({ slug }) => slug))
-  );
-  return featuredProjects.map(({ slug, date, comments }) => {
-    const project: BestOfJS.Project | undefined = projects.find(
-      (project) => project.slug === slug
-    );
-    if (!project) return null;
-    return {
-      comments: comments || [],
-      date: date || new Date(project.created_at),
-      ...project,
-    };
-  });
+  ).filter(Boolean);
+  return featuredProjects
+    .map(({ slug, date, comments }) => {
+      const project: BestOfJS.Project | undefined = projects.find(
+        (project) => project.slug === slug
+      );
+      if (!project) return null;
+      return {
+        comments: comments || [],
+        date: date || new Date(project.created_at),
+        ...project,
+      };
+    })
+    .filter(Boolean);
 }
 
 export const Timeline = () => {


### PR DESCRIPTION
## Goal
- Fix broken page https://bestofjs.org/timeline 
![cannot access timeline page](https://user-images.githubusercontent.com/8603085/169594261-f034b8b4-1a78-42b7-b342-c22b623cec6d.png)

After some investigation, the reason this page is broken is the data in `src/components/timeline/featured-projects.json`, which has `angular-1` and `vuejs`. But data get from https://bestofjs-static-api.vercel.app/projects.json (`state.entities.projects`) does not have `angular-1` and `vuejs` (but have `angular`, `vuejs-2`, `vuejs-3`). Then, logic in `useTimelineProjects` make the page broken.

```js
function useTimelineProjects() {
  const projects: BestOfJS.Project[] = useSelector(
    findProjectsByIds(featuredProjects.map(({ slug }) => slug))
  ); // CONTAIN `null`
  return featuredProjects.map(({ slug, date, comments }) => {
    const project: BestOfJS.Project | undefined = projects.find(
      (project) => project.slug === slug // CANNOT FIND slug of null
    );
    if (!project) return null;
    return {
      comments: comments || [],
      date: date || new Date(project.created_at),
      ...project,
    };
  }); // CONTAIN null project
}
```

This PR tries to make the page not broken. It just doesn't render the project which is missing data. However, the root cause is the data from the server is missing/ inconsistent. We still need to update the data since data inconsistency is the root cause. (But unluckily, I haven't found where to update, please help with that).

## How to test
- `npm run start` then head to `http://localhost:3000/timeline`. We should be able to see the page rendered (without Angular and Vue, have 18/20 projects).

## Screenshots
See above