### PR TITLE
Remove unused config for ejs

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,11 +18,6 @@ export default defineConfig((props) => {
       react(),
       tsconfigPaths(),
       createHtmlPlugin({
-        inject: {
-          data: {
-            env,
-          },
-        },
         minify: true,
       }),
     ].filter(Boolean),


### PR DESCRIPTION
## Goal
- Remove redundant `ejs` config in `vite.config.ts`.
- I thought that config `inject.data.env` is to enject to `process.env`, but it's not correct. accessing `<% if (process.env.VERCEL_ENV === 'production') { %>` is supported by `ejs` natively.
- If I config as
```js
inject: {
  data: {
    env,
  },
},
```
I should write in the `index.html` like this
```js
<% if (env.VERCEL_ENV === 'production') { %>
```
But I use `process.env.VERCEL_ENV`, so no need any injection.

## How to test
Change 
- Build the app in PROD mode
```command
VERCEL_ENV=production npm run build
```
=> We should see the cloudflare analytics in the index.html

- Build the app in Preview mode
```command
VERCEL_ENV=preview npm run build
```
=> We should not see the cloudflare analytics in the index.html

cc: @michaelrambeau 