### PR TITLE
Fix tag link from page N

### DIFF
--- a/src/components/tags/project-tag.tsx
+++ b/src/components/tags/project-tag.tsx
@@ -31,6 +31,7 @@ export const ProjectTag = ({
   const { updateLocation } = useNextLocation();
   const nextLocation = updateLocation((state) => ({
     ...state,
+    page: 1,
     selectedTags: appendTag ? [...state.selectedTags, tag.code] : [tag.code],
     query: "",
   }));


### PR DESCRIPTION
## Goal

Fix the tag links from a page whose number is greater than 1.

E.g. https://bestofjs.org/projects?tags=component&page=2

When clicking on a tag link, the pagination should be reset.

## How to test

- Go to the "component toolkit" page: https://bestofjs.org/projects?tags=component
- Go to the next page (page number 2) => https://bestofjs.org/projects?tags=component&page=2
- Click on any tag ("design system") for example: a page with no result will be displayed in production! https://bestofjs.org/projects?tags=design-system&page=2 because the page number is not reset

## Screenshot

Before the correction:

![image](https://user-images.githubusercontent.com/5546996/170260708-f6015c7a-1634-43ef-b4d5-eb24c2ac91d0.png)
