### PR TITLE
Fix logos displayed as huge images in the README section of project details page

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { Root } from "./root";
 import { initializeColorMode } from "components/core/color-mode";
 
 // Old-fashioned stylesheets
+import "./stylesheets/css-reset.css";
 import "./stylesheets/base.css";
 
 function start() {

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -11,7 +11,7 @@ import { AuthProvider } from "containers/auth-container";
 
 export const Root = () => {
   return (
-    <ChakraProvider theme={customTheme} resetCSS={true}>
+    <ChakraProvider theme={customTheme} resetCSS={false}>
       <Router>
         <AppWithRouter />
       </Router>

--- a/src/stylesheets/css-reset.css
+++ b/src/stylesheets/css-reset.css
@@ -1,0 +1,236 @@
+/* 
+Created from ChakraUI v1
+https://github.com/chakra-ui/chakra-ui/blob/v1/packages/css-reset/src/css-reset.tsx
+Unwanted styles have been commented out
+*/
+html {
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  font-family: system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  touch-action: manipulation;
+}
+body {
+  position: relative;
+  min-height: 100%;
+  font-feature-settings: "kern";
+}
+*,
+*::before,
+*::after {
+  border-width: 0;
+  border-style: solid;
+  box-sizing: border-box;
+}
+main {
+  display: block;
+}
+hr {
+  border-top-width: 1px;
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+pre,
+code,
+kbd,
+samp {
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1em;
+}
+a {
+  background-color: transparent;
+  color: inherit;
+  text-decoration: inherit;
+}
+abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+b,
+strong {
+  font-weight: bold;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sub {
+  bottom: -0.25em;
+}
+sup {
+  top: -0.5em;
+}
+img {
+  border-style: none;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+button,
+input {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+legend {
+  box-sizing: border-box;
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+}
+progress {
+  vertical-align: baseline;
+}
+textarea {
+  overflow: auto;
+}
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none !important;
+}
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none !important;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+details {
+  display: block;
+}
+summary {
+  display: list-item;
+}
+template {
+  display: none;
+}
+[hidden] {
+  display: none !important;
+}
+body,
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+button {
+  background: transparent;
+  padding: 0;
+}
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+ol,
+ul {
+  margin: 0;
+  padding: 0;
+}
+textarea {
+  resize: vertical;
+}
+button,
+[role="button"] {
+  cursor: pointer;
+}
+button::-moz-focus-inner {
+  border: 0 !important;
+}
+table {
+  border-collapse: collapse;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  padding: 0;
+  line-height: inherit;
+  color: inherit;
+}
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+}
+/* Removed because of projects logos in README sections
+/* img,
+video {
+  max-width: 100%;
+  height: auto;
+} */
+[data-js-focus-visible] :focus:not([data-focus-visible-added]) {
+  outline: none;
+  box-shadow: none;
+}
+select::-ms-expand {
+  display: none;
+}

--- a/src/stylesheets/css-reset.css
+++ b/src/stylesheets/css-reset.css
@@ -221,12 +221,12 @@ embed,
 object {
   display: block;
 }
-/* Removed because of projects logos in README sections
-/* img,
+img,
 video {
   max-width: 100%;
-  height: auto;
-} */
+  /* The following rule was removed because of projects logos in README sections #152 */
+  /* height: auto; */
+}
 [data-js-focus-visible] :focus:not([data-focus-visible-added]) {
   outline: none;
   box-shadow: none;


### PR DESCRIPTION
## Goal

Fix a visual bug in some project README sections: some images are huge (taking all the available width, instead of a fixed width).

Examples:

- Expo project: https://bestofjs.org/projects/expo
- tRPC project: https://bestofjs.org/projects/trpc

Reason: Chakra UI comes with a Reset CSS file, whose style cause the problem.

https://github.com/chakra-ui/chakra-ui/blob/v1/packages/css-reset/src/css-reset.tsx

```css
img,
video {
  max-width: 100%;
  height: auto;
}
```

Rather than trying to override the styles (it was my first attempt but it's not trivial), I think it's cleaner to use our own Reset CSS file, created from Chakra UI's one.


## How to test

Open the projects mentioned above and check that the logo is displayed correctly (like in the original GitHub README!)

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/5546996/183278091-e96d9971-82dd-4453-a4ed-eac4ecd4f715.png)

### After

![image](https://user-images.githubusercontent.com/5546996/183278117-badb04f3-4ec8-4d8d-8019-4f2eee423774.png)

