### PR TITLE
🔗 Open new tab when clicking on Github or project's homepage

### DIFF
--- a/src/components/project-list/project-table.tsx
+++ b/src/components/project-list/project-table.tsx
@@ -85,6 +85,7 @@ const ProjectTableRow = ({
             as="a"
             href={project.repository}
             rel="noopener noreferrer"
+            target="_blank"
             icon={<GoMarkGithub size={20} />}
             aria-label="GitHub repository"
             variant="ghost"
@@ -95,6 +96,8 @@ const ProjectTableRow = ({
             <IconButton
               as="a"
               href={project.url}
+              rel="noopener noreferrer"
+              target="_blank"
               icon={<GoHome size={20} />}
               aria-label="Project's homepage"
               variant="ghost"


### PR DESCRIPTION
## Goal
- Open a link in the GitHub link and the Project's Homepage should open a new tab instead of navigating directly

## How to test
- Click on any GitHub link or Project's Homepage of `ProjectTableRow`

## Screenshots
![Aug-19-2022 15-12-02](https://user-images.githubusercontent.com/8603085/185574815-0f082b88-71e7-46b8-b915-18c2858a5cde.gif)

