### PR TITLE
Fix Next.js 16 error build error

### DIFF
--- a/apps/web/src/app/hall-of-fame/page.tsx
+++ b/apps/web/src/app/hall-of-fame/page.tsx
@@ -1,3 +1,5 @@
+import { cacheTag } from "next/cache";
+
 import { db } from "@repo/db";
 import { findHallOfFameMembers } from "@repo/db/hall-of-fame";
 
@@ -11,6 +13,8 @@ const forceLoadingState = false; // set to true when debugging the loading state
 const searchStateParser = new HallOfFameSearchStateParser();
 
 export default async function HallOfFamePage() {
+  "use cache";
+  cacheTag("hall-of-fame");
   if (forceLoadingState) return <Loading />;
 
   const { searchState, buildPageURL } = searchStateParser.parse({});

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -1,3 +1,5 @@
+"use cache";
+
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
@@ -73,7 +75,6 @@ export default async function ProjectDetailsPage(props: PageProps) {
 }
 
 async function getProjectDetailsData(slug: string) {
-  "use cache";
   cacheLife("daily");
   cacheTag("project-details", slug);
   return await projectService.getProjectBySlug(slug);


### PR DESCRIPTION
## Goal

Fix the build error in production after having merged `dvelopment` into `master`, when pre-rendering a route `/projects/[slug]`

I don't understand why this error didn't happened in the branch's PR #380 🙀 

```
Cannot access Request information or uncached data in `generateMetadata()` in an otherwise entirely static route`
```

Fixed bu sharing cache logic between `generateMetadata()` and default page function, following the instructions from:

https://nextjs.org/docs/messages/next-prerender-dynamic-metadata

#### Other errors:

```
Error: Route "/hall-of-fame" used `require('node:crypto').randomBytes(size)` before accessing either uncached data (e.g. `fetch()`) or Request data (e.g. `cookies()`, `headers()`, `connection()`, and `searchParams`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
```

```
Error: Route "/projects/[slug]" used `new Date()` before accessing either uncached data (e.g. `fetch()`) or Request data (e.g. `cookies()`, `headers()`, `connection()`, and `searchParams`). Accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time
```

## How to test

- Ensure the project build!

## Screenshots

<img width="1287" height="992" alt="image" src="https://github.com/user-attachments/assets/1e0ce4d5-b234-4878-8095-9d341bd1c155" />

