### PR TITLE
fix image mode loading

### DIFF
--- a/apps/admin/src/components/project-logo.tsx
+++ b/apps/admin/src/components/project-logo.tsx
@@ -74,7 +74,7 @@ export function getProjectLogoUrl(
   return url;
 }
 
-function getProjectLogoURL(input: string, colorMode: string) {
+function getProjectLogoURL(input: string, colorMode: "dark" | "light") {
   const [main, extension] = input.split(".");
   const filename = colorMode === "dark" ? `${main}.dark.${extension}` : input;
   return `https://bestofjs.org/logos/${filename}`;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -163,3 +163,8 @@ footer::after {
     #9c0042 80%
   );
 }
+
+.dark .light-mode-only,
+.light .dark-mode-only {
+  display: none;
+}

--- a/apps/web/src/components/core/project-logo.tsx
+++ b/apps/web/src/components/core/project-logo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Fragment } from "react";
 import Image from "next/image";
-import { useTheme } from "next-themes";
 
 import { cn } from "@/lib/utils";
 
@@ -67,16 +67,23 @@ export function ProjectCustomLogo({
 }: {
   filename: string;
 } & BaseProps) {
-  const colorMode = useColorMode();
-  const imageURL = getProjectCustomLogoURL(filename, colorMode);
   return (
-    <Image
-      src={imageURL}
-      width={size}
-      height={size}
-      alt={name}
-      className={cn(className, "project-logo")}
-    />
+    <Fragment>
+      <Image
+        src={getProjectCustomLogoURL(filename, "light")}
+        width={size}
+        height={size}
+        alt={name}
+        className={cn(className, "project-logo", "light-mode-only")}
+      />
+      <Image
+        src={getProjectCustomLogoURL(filename, "dark")}
+        width={size}
+        height={size}
+        alt={name}
+        className={cn(className, "project-logo", "dark-mode-only")}
+      />
+    </Fragment>
   );
 }
 
@@ -98,9 +105,4 @@ export function GitHubAvatar({
       className={cn(className, "project-logo")}
     />
   );
-}
-
-function useColorMode() {
-  const { resolvedTheme } = useTheme();
-  return (resolvedTheme || "dark") as "dark" | "light";
 }

--- a/apps/web/src/components/core/project-utils.ts
+++ b/apps/web/src/components/core/project-utils.ts
@@ -1,7 +1,7 @@
 export function getProjectLogoURL(
   project: BestOfJS.Project,
   size: number,
-  colorMode: string,
+  colorMode: "dark" | "light",
 ) {
   if (project.logo) {
     return getProjectCustomLogoURL(project.logo, colorMode);
@@ -13,7 +13,10 @@ export function getProjectLogoURL(
  * Return the relative URL of the project's SVG logo, taking into account the color mode
  * E.g. `/logos/react.dark.svg` for dark mode or `/logos/parcel.svg` for light mode
  */
-export function getProjectCustomLogoURL(filename: string, colorMode: string) {
+export function getProjectCustomLogoURL(
+  filename: string,
+  colorMode: "light" | "dark",
+) {
   const [main, extension] = filename.split(".");
   const actualFilename =
     colorMode === "dark" ? `${main}.dark.${extension}` : filename;


### PR DESCRIPTION
Solve https://github.com/bestofjs/bestofjs/issues/337#issuecomment-3657860293, the problem can be reproduce having the light mode by default and browsing for the first time, you will see this:

https://github.com/user-attachments/assets/3bf9eb11-f7d7-4a96-8a82-18169742b9db

Why it's happening is explained in https://github.com/pacocoursey/next-themes?tab=readme-ov-file#avoid-hydration-mismatch. The simple version is that on the server side, when the page is SSR, the server doesn't know what the mode client side.

There are two different ways to solve this, documented on that same next-themes page:

1. By waiting for the page de be hydrated:

```diff
diff --git a/apps/web/src/components/core/project-logo.tsx b/apps/web/src/components/core/project-logo.tsx
index 6758760a..1404778e 100644
--- a/apps/web/src/components/core/project-logo.tsx
+++ b/apps/web/src/components/core/project-logo.tsx
@@ -1,5 +1,6 @@
 "use client";

+import { useState, useEffect } from 'react';
 import Image from "next/image";
 import { useTheme } from "next-themes";

@@ -67,8 +68,20 @@ export function ProjectCustomLogo({
 }: {
   filename: string;
 } & BaseProps) {
-  const colorMode = useColorMode();
-  const imageURL = getProjectCustomLogoURL(filename, colorMode);
+  const { resolvedTheme: colorMode } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  let imageURL;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (mounted) {
+    imageURL = getProjectCustomLogoURL(filename, colorMode!);
+  } else {
+    imageURL = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+  }
+
   return (
     <Image
       src={imageURL}
@@ -99,8 +112,3 @@ export function GitHubAvatar({
     />
   );
 }
-
-function useColorMode() {
-  const { resolvedTheme } = useTheme();
-  return (resolvedTheme || "dark") as "dark" | "light";
-}
```

2. Or by having two images, toggling them with CSS. It's the strategy use on https://nextjs.org/. It's better because it allows to load the image asset a lot sooner.