### PR TITLE
Fix missing contributor count in GitHub sections

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,8 +20,7 @@
     "debug": "^4.3.7",
     "emoji-regex": "^10.3.0",
     "es-toolkit": "^1.31.0",
-    "graphql-request": "^7.0.1",
-    "scrape-it": "^6.1.2"
+    "graphql-request": "^7.0.1"
   },
   "devDependencies": {
     "@types/bun": "^1.1.12"

--- a/packages/api/src/github/github-api-client.ts
+++ b/packages/api/src/github/github-api-client.ts
@@ -1,6 +1,5 @@
 import debugPackage from "debug";
 import { GraphQLClient } from "graphql-request";
-import scrapeIt from "scrape-it";
 
 import { processReadMeHtml } from "./process-readme-html";
 import { extractRepoInfo, queryRepoInfo } from "./repo-info-query";
@@ -100,17 +99,23 @@ export function createGitHubClient() {
     fetchRepoInfoFallback,
 
     async fetchContributorCount(fullName: string) {
-      debug(`Fetching the number of contributors by scraping`, fullName);
-      const url = `https://github.com/${fullName}`;
-      const {
-        data: { contributor_count },
-      } = await scrapeIt<{ contributor_count: number }>(url, {
-        contributor_count: {
-          selector: `a[href="/${fullName}/graphs/contributors"] .Counter`,
-          convert: toInteger,
-        },
-      });
-      return contributor_count;
+      debug(`Fetching contributor count from REST API`, fullName);
+      const query = new URLSearchParams({ per_page: "1", anon: "true" });
+      const response = await makeRestApiRequest(
+        `repos/${fullName}/contributors?${query}`,
+      );
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(
+          `GitHub contributors request failed (${response.status}): ${body}`,
+        );
+      }
+      const data: unknown = await response.json();
+      const contributors = Array.isArray(data) ? data : [];
+      const lastPage = parseLastPageFromLinkHeader(
+        response.headers.get("link"),
+      );
+      return lastPage ?? contributors.length;
     },
 
     async fetchUserInfo(login: string) {
@@ -136,10 +141,19 @@ export function createGitHubClient() {
   };
 }
 
-// Convert a String from the web page E.g. `1,300` into an Integer
-const toInteger = (source: string) => {
-  const onlyNumbers = source.replace(/[^\d]/, "");
-  return !onlyNumbers || Number.isNaN(Number(onlyNumbers))
-    ? 0
-    : parseInt(onlyNumbers, 10);
-};
+/** GitHub pagination: `Link` header entry with `rel="last"` includes `page=N`. */
+function parseLastPageFromLinkHeader(link: string | null): number | undefined {
+  if (!link) return undefined;
+  for (const part of link.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed.includes('rel="last"')) continue;
+    const urlMatch = trimmed.match(/^<([^>]+)>/);
+    if (!urlMatch) continue;
+    const page = new URL(urlMatch[1]).searchParams.get("page");
+    if (page) {
+      const n = parseInt(page, 10);
+      if (!Number.isNaN(n)) return n;
+    }
+  }
+  return undefined;
+}

--- a/packages/api/src/github/github-api-client.ts
+++ b/packages/api/src/github/github-api-client.ts
@@ -4,6 +4,7 @@ import { GraphQLClient } from "graphql-request";
 import { processReadMeHtml } from "./process-readme-html";
 import { extractRepoInfo, queryRepoInfo } from "./repo-info-query";
 import { extractUserInfo, queryUserInfo } from "./user-info-query";
+import { parseLastPageFromLinkHeader } from "./utils";
 
 const debug = debugPackage("github");
 
@@ -139,21 +140,4 @@ export function createGitHubClient() {
       return readme;
     },
   };
-}
-
-/** GitHub pagination: `Link` header entry with `rel="last"` includes `page=N`. */
-function parseLastPageFromLinkHeader(link: string | null): number | undefined {
-  if (!link) return undefined;
-  for (const part of link.split(",")) {
-    const trimmed = part.trim();
-    if (!trimmed.includes('rel="last"')) continue;
-    const urlMatch = trimmed.match(/^<([^>]+)>/);
-    if (!urlMatch) continue;
-    const page = new URL(urlMatch[1]).searchParams.get("page");
-    if (page) {
-      const n = parseInt(page, 10);
-      if (!Number.isNaN(n)) return n;
-    }
-  }
-  return undefined;
 }

--- a/packages/api/src/github/github-client.test.ts
+++ b/packages/api/src/github/github-client.test.ts
@@ -1,54 +1,57 @@
 /**
- * Manual tests to be launched with `bun test`
+ * Manual integration tests (require GITHUB_ACCESS_TOKEN). Run:
+ * `GITHUB_ACCESS_TOKEN=... bun test src/github/github-client.test.ts`
  */
 
 import { createGitHubClient } from "./github-api-client";
 import { describe, expect, test } from "bun:test";
 
-const client = createGitHubClient();
+if (process.env.GITHUB_ACCESS_TOKEN) {
+  const client = createGitHubClient();
 
-describe("GitHub API client", async () => {
-  test("Moved repo", async () => {
-    const repoInfo = await client.fetchRepoInfo("foreverjs/forever");
-    expect(repoInfo.full_name).toBe("foreversd/forever");
-  });
+  describe("GitHub API client (integration)", () => {
+    test("Moved repo", async () => {
+      const repoInfo = await client.fetchRepoInfo("foreverjs/forever");
+      expect(repoInfo.full_name).toBe("foreversd/forever");
+    });
 
-  test("Repo fallback", async () => {
-    const repoInfo = await client.fetchRepoInfoFallback("foreverjs/forever");
-    expect(repoInfo.full_name).toBe("foreversd/forever");
-  });
+    test("Repo fallback", async () => {
+      const repoInfo = await client.fetchRepoInfoFallback("foreverjs/forever");
+      expect(repoInfo.full_name).toBe("foreversd/forever");
+    });
 
-  test("Repo info", async () => {
-    const repoInfo = await client.fetchRepoInfo("expressjs/express");
-    expect(repoInfo.full_name).toBe("expressjs/express");
-    expect(repoInfo.topics).toEqual([
-      "javascript",
-      "nodejs",
-      "express",
-      "server",
-    ]);
-  });
+    test("Repo info", async () => {
+      const repoInfo = await client.fetchRepoInfo("expressjs/express");
+      expect(repoInfo.full_name).toBe("expressjs/express");
+      expect(repoInfo.topics).toEqual([
+        "javascript",
+        "nodejs",
+        "express",
+        "server",
+      ]);
+    });
 
-  test("Repo description", async () => {
-    const { description } = await client.fetchRepoInfo("nodejs/node");
-    expect(description).toBe("Node.js JavaScript runtime");
-  });
+    test("Repo description", async () => {
+      const { description } = await client.fetchRepoInfo("nodejs/node");
+      expect(description).toBe("Node.js JavaScript runtime");
+    });
 
-  test("Contributor count", async () => {
-    const contributorCount =
-      await client.fetchContributorCount("expressjs/express");
-    expect(contributorCount).toBeGreaterThan(350);
-  });
+    test("Contributor count", async () => {
+      const contributorCount =
+        await client.fetchContributorCount("expressjs/express");
+      expect(contributorCount).toBeGreaterThan(350);
+    });
 
-  test("Contributor count (bestofjs/bestofjs)", async () => {
-    const contributorCount =
-      await client.fetchContributorCount("bestofjs/bestofjs");
-    expect(contributorCount).toBeGreaterThanOrEqual(25);
-    expect(contributorCount).toBeLessThanOrEqual(50);
-  });
+    test("Contributor count (bestofjs/bestofjs)", async () => {
+      const contributorCount =
+        await client.fetchContributorCount("bestofjs/bestofjs");
+      expect(contributorCount).toBeGreaterThanOrEqual(25);
+      expect(contributorCount).toBeLessThanOrEqual(50);
+    });
 
-  test("User info", async () => {
-    const userInfo = await client.fetchUserInfo("sindresorhus");
-    expect(userInfo.followers).toBeGreaterThan(30_000);
+    test("User info", async () => {
+      const userInfo = await client.fetchUserInfo("sindresorhus");
+      expect(userInfo.followers).toBeGreaterThan(30_000);
+    });
   });
-});
+}

--- a/packages/api/src/github/github-client.test.ts
+++ b/packages/api/src/github/github-client.test.ts
@@ -37,7 +37,14 @@ describe("GitHub API client", async () => {
   test("Contributor count", async () => {
     const contributorCount =
       await client.fetchContributorCount("expressjs/express");
-    expect(contributorCount).toBeGreaterThan(300);
+    expect(contributorCount).toBeGreaterThan(350);
+  });
+
+  test("Contributor count (bestofjs/bestofjs)", async () => {
+    const contributorCount =
+      await client.fetchContributorCount("bestofjs/bestofjs");
+    expect(contributorCount).toBeGreaterThanOrEqual(25);
+    expect(contributorCount).toBeLessThanOrEqual(50);
   });
 
   test("User info", async () => {

--- a/packages/api/src/github/index.ts
+++ b/packages/api/src/github/index.ts
@@ -1,1 +1,2 @@
 export * from "./github-api-client";
+export * from "./utils";

--- a/packages/api/src/github/utils.test.ts
+++ b/packages/api/src/github/utils.test.ts
@@ -1,0 +1,43 @@
+import { parseLastPageFromLinkHeader } from "./utils";
+import { describe, expect, test } from "bun:test";
+
+describe("parseLastPageFromLinkHeader", () => {
+  test("returns undefined for null", () => {
+    expect(parseLastPageFromLinkHeader(null)).toBeUndefined();
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(parseLastPageFromLinkHeader("")).toBeUndefined();
+  });
+
+  test("returns undefined when there is no rel last", () => {
+    const link =
+      '<https://api.github.com/repositories/123/contributors?per_page=1&page=2>; rel="next"';
+    expect(parseLastPageFromLinkHeader(link)).toBeUndefined();
+  });
+
+  test("parses single rel last link", () => {
+    const link =
+      '<https://api.github.com/repositories/123/contributors?per_page=1&page=347>; rel="last"';
+    expect(parseLastPageFromLinkHeader(link)).toBe(347);
+  });
+
+  test("parses rel last when next is also present (GitHub style)", () => {
+    const link =
+      '<https://api.github.com/repositories/123/contributors?per_page=1&page=2>; rel="next", ' +
+      '<https://api.github.com/repositories/123/contributors?per_page=1&page=347>; rel="last"';
+    expect(parseLastPageFromLinkHeader(link)).toBe(347);
+  });
+
+  test("does not throw when rel last URL is invalid", () => {
+    const link = '<not-a-valid-absolute-url>; rel="last"';
+    expect(parseLastPageFromLinkHeader(link)).toBeUndefined();
+  });
+
+  test("skips rel last segment with invalid URL and uses a later valid one", () => {
+    const link =
+      '<not-a-valid-absolute-url>; rel="last", ' +
+      '<https://api.github.com/repositories/123/contributors?per_page=1&page=347>; rel="last"';
+    expect(parseLastPageFromLinkHeader(link)).toBe(347);
+  });
+});

--- a/packages/api/src/github/utils.ts
+++ b/packages/api/src/github/utils.ts
@@ -1,0 +1,21 @@
+/** GitHub pagination: `Link` header entry with `rel="last"` includes `page=N`. */
+export function parseLastPageFromLinkHeader(
+  link: string | null,
+): number | undefined {
+  if (!link) return undefined;
+  for (const part of link.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed.includes('rel="last"')) continue;
+    // `^<([^>]+)>`: segment starts with `<url>`; capture group 1 is the URL (runs until the next `>`).
+    const urlMatch = trimmed.match(/^<([^>]+)>/);
+    if (!urlMatch) continue;
+    try {
+      const page = new URL(urlMatch[1]).searchParams.get("page");
+      if (page) {
+        const n = parseInt(page, 10);
+        if (!Number.isNaN(n)) return n;
+      }
+    } catch {}
+  }
+  return undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,9 +621,6 @@ importers:
       graphql-request:
         specifier: ^7.0.1
         version: 7.0.1(graphql@16.9.0)
-      scrape-it:
-        specifier: ^6.1.2
-        version: 6.1.2(debug@4.4.1)
     devDependencies:
       '@types/bun':
         specifier: ^1.1.12
@@ -4073,9 +4070,6 @@ packages:
   '@types/bun@1.2.21':
     resolution: {integrity: sha512-NiDnvEqmbfQ6dmZ3EeUO577s4P5bf4HCTXtI6trMc6f6RzirY5IrF3aIookuSpyslFzrnvv2lmEWv5HyC1X79A==}
 
-  '@types/cheerio@0.22.35':
-    resolution: {integrity: sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==}
-
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -4469,9 +4463,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  assured@1.0.15:
-    resolution: {integrity: sha512-EVb4T+6m5VdlTJ6gbv4WjBM1rHfzXP2BspsQ6VLswcnIQSabjJy7A9YEuG4/KmfF+9OEuT5xhqVJ+V1tClD5ww==}
-
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -4492,9 +4483,6 @@ packages:
   available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
-
-  axios@1.7.2:
-    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
 
   b4a@1.6.4:
     resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
@@ -4530,9 +4518,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  barbe@3.0.16:
-    resolution: {integrity: sha512-WSJbowJ8dUfDUSWSZzJDD2BP+xwbLdGPbZMStzgUX8UDSS2stPLvi9pwCIsU9k8RXU6x56nIJzJYSfFct3C1+Q==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4706,16 +4691,6 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
-
-  cheerio-req@2.0.0:
-    resolution: {integrity: sha512-g4+YW7woEK8XJomPlqoBET99aVngZpZdp6lYq7iioVqNNLIXjKagZzyCe/wd7d268fCNgF6BzQG6yMkbLaILQQ==}
-
-  cheerio-select@2.1.0:
-    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
-
-  cheerio@1.0.0-rc.12:
-    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
-    engines: {node: '>= 6'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -4975,9 +4950,6 @@ packages:
   css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
 
-  css-select@5.1.0:
-    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
-
   css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
     engines: {node: '>=8.0.0'}
@@ -5087,9 +5059,6 @@ packages:
   defer-to-connect@1.1.3:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
 
-  deffy@2.2.4:
-    resolution: {integrity: sha512-pLc9lsbsWjr6RxmJ2OLyvm+9l4j1yK69h+TML/gUit/t3vTijpkNGh8LioaJYTGO7F25m6HZndADcUOo2PsiUg==}
-
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -5168,9 +5137,6 @@ packages:
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
-  dom-serializer@2.0.0:
-    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
-
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
@@ -5183,19 +5149,12 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
-  domhandler@5.0.3:
-    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
-    engines: {node: '>= 4'}
-
   dompurify@3.3.2:
     resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
     engines: {node: '>=20'}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
-
-  domutils@3.1.0:
-    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -5394,9 +5353,6 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
-
-  err@2.1.12:
-    resolution: {integrity: sha512-C0XHNJOnH072AC8q0L5oclAZvBCD8nzBb24bcHSqEkurDHyRo6bpOztgddHtH4Ik/9evmBCVW0nEY0NdnSt46Q==}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -5718,15 +5674,6 @@ packages:
     resolution: {integrity: sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==}
     engines: {node: '>=10'}
 
-  follow-redirects@1.15.6:
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
@@ -5736,10 +5683,6 @@ packages:
 
   form-data@3.0.1:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
-    engines: {node: '>= 6'}
-
-  form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
 
   formdata-node@6.0.3:
@@ -5822,9 +5765,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  function.name@1.0.13:
-    resolution: {integrity: sha512-mVrqdoy5npWZyoXl4DxCeuVF6delDcQjVS9aPdvLYlBxtMTZDR2B5GVEQEoM1jJyspCqg3C0v4ABkLE7tp9xFA==}
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -6014,9 +5954,6 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  htmlparser2@8.0.2:
-    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
-
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -6172,9 +6109,6 @@ packages:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
-
-  is-empty-obj@1.0.13:
-    resolution: {integrity: sha512-guOzs/jAs4sR4NEBLVaUfaaO9lmFrfSYXZll5iRnUQ+h3beA7dqXICZd2FrvH6bIOElttZZs9ryruuW7Yzni6g==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -6338,9 +6272,6 @@ packages:
   istanbul-reports@3.1.6:
     resolution: {integrity: sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==}
     engines: {node: '>=8'}
-
-  iterate-object@1.3.4:
-    resolution: {integrity: sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw==}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -7101,9 +7032,6 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  noop6@1.0.9:
-    resolution: {integrity: sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA==}
-
   normalize-path@1.0.0:
     resolution: {integrity: sha512-7WyT0w8jhpDStXRq5836AMmihQwq2nrUVQrgjvUo/p/NZf9uy/MeJ246lBJVmWuYXMlJuG9BNZHF0hWjfTbQUA==}
     engines: {node: '>=0.10.0'}
@@ -7157,9 +7085,6 @@ packages:
 
   nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
-
-  obj-def@1.0.9:
-    resolution: {integrity: sha512-bQ4ya3VYD6FAA1+s6mEhaURRHSmw4+sKaXE6UyXZ1XDYc5D+c7look25dFdydmLd18epUegh398gdDkMUZI9xg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -7303,14 +7228,8 @@ packages:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
 
-  parse5-htmlparser2-tree-adapter@7.0.0:
-    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
-
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
-
-  parse5@7.1.2:
-    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -7571,9 +7490,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -7842,9 +7758,6 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
-  regex-escape@3.4.10:
-    resolution: {integrity: sha512-qEqf7uzW+iYcKNLMDFnMkghhQBnGdivT6KqVQyKsyjSWnoFyooXVnxrw9dtv3AFLnD6VBGXxtZGAQNFGFTnCqA==}
-
   regexp.prototype.flags@1.5.3:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
@@ -7976,12 +7889,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  scrape-it-core@1.0.0:
-    resolution: {integrity: sha512-R2IVyqDRoQsLue81+NLSJUnvqVmzP3YXPBVjvtMPQa4GiDCYjHFN5aDhEOsETqj90w0aHzqScDrSUQ64NvKROg==}
-
-  scrape-it@6.1.2:
-    resolution: {integrity: sha512-58DMh1/I68d49wP3By+9ulwy6Nwy52iix13m+gB1KjkIpREa8cyqMXTHffgn1BWgHUFHr5ON9SNbcoMSuCFmXA==}
-
   screenfull@5.2.0:
     resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
     engines: {node: '>=0.10.0'}
@@ -8103,9 +8010,6 @@ packages:
   slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
-
-  sliced@1.0.1:
-    resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
 
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
@@ -8599,9 +8503,6 @@ packages:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  typpy@2.3.13:
-    resolution: {integrity: sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -12608,10 +12509,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@types/cheerio@0.22.35':
-    dependencies:
-      '@types/node': 20.12.14
-
   '@types/cookie@0.6.0': {}
 
   '@types/debug@4.1.12':
@@ -13053,11 +12950,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  assured@1.0.15:
-    dependencies:
-      noop6: 1.0.9
-      sliced: 1.0.1
-
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -13077,14 +12969,6 @@ snapshots:
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.5: {}
-
-  axios@1.7.2(debug@4.4.1):
-    dependencies:
-      follow-redirects: 1.15.6(debug@4.4.1)
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   b4a@1.6.4: {}
 
@@ -13148,12 +13032,6 @@ snapshots:
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.28.5)
 
   balanced-match@1.0.2: {}
-
-  barbe@3.0.16:
-    dependencies:
-      iterate-object: 1.3.4
-      regex-escape: 3.4.10
-      typpy: 2.3.13
 
   base64-js@1.5.1: {}
 
@@ -13358,32 +13236,6 @@ snapshots:
   char-regex@2.0.1: {}
 
   check-error@2.1.1: {}
-
-  cheerio-req@2.0.0(debug@4.4.1):
-    dependencies:
-      axios: 1.7.2(debug@4.4.1)
-      cheerio: 1.0.0-rc.12
-    transitivePeerDependencies:
-      - debug
-
-  cheerio-select@2.1.0:
-    dependencies:
-      boolbase: 1.0.0
-      css-select: 5.1.0
-      css-what: 6.1.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.1.0
-
-  cheerio@1.0.0-rc.12:
-    dependencies:
-      cheerio-select: 2.1.0
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      domutils: 3.1.0
-      htmlparser2: 8.0.2
-      parse5: 7.1.2
-      parse5-htmlparser2-tree-adapter: 7.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -13638,14 +13490,6 @@ snapshots:
       domutils: 2.8.0
       nth-check: 2.1.1
 
-  css-select@5.1.0:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.1.0
-      domhandler: 5.0.3
-      domutils: 3.1.0
-      nth-check: 2.1.1
-
   css-tree@1.1.3:
     dependencies:
       mdn-data: 2.0.14
@@ -13738,10 +13582,6 @@ snapshots:
 
   defer-to-connect@1.1.3: {}
 
-  deffy@2.2.4:
-    dependencies:
-      typpy: 2.3.13
-
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -13803,12 +13643,6 @@ snapshots:
       domhandler: 4.3.1
       entities: 2.2.0
 
-  dom-serializer@2.0.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
-
   domelementtype@2.3.0: {}
 
   domexception@2.0.1:
@@ -13816,10 +13650,6 @@ snapshots:
       webidl-conversions: 5.0.0
 
   domhandler@4.3.1:
-    dependencies:
-      domelementtype: 2.3.0
-
-  domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
 
@@ -13832,12 +13662,6 @@ snapshots:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
-
-  domutils@3.1.0:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
 
   dot-case@3.0.4:
     dependencies:
@@ -13946,12 +13770,6 @@ snapshots:
   entities@4.5.0: {}
 
   env-paths@2.2.1: {}
-
-  err@2.1.12:
-    dependencies:
-      barbe: 3.0.16
-      iterate-object: 1.3.4
-      typpy: 2.3.13
 
   error-ex@1.3.2:
     dependencies:
@@ -14421,10 +14239,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  follow-redirects@1.15.6(debug@4.4.1):
-    optionalDependencies:
-      debug: 4.4.1
-
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -14435,12 +14249,6 @@ snapshots:
       signal-exit: 4.1.0
 
   form-data@3.0.1:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-
-  form-data@4.0.0:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -14521,10 +14329,6 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
-
-  function.name@1.0.13:
-    dependencies:
-      noop6: 1.0.9
 
   functions-have-names@1.2.3: {}
 
@@ -14737,13 +14541,6 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.19.2
 
-  htmlparser2@8.0.2:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.1.0
-      entities: 4.5.0
-
   http-cache-semantics@4.1.1: {}
 
   http-errors@2.0.0:
@@ -14896,8 +14693,6 @@ snapshots:
 
   is-docker@2.2.1: {}
 
-  is-empty-obj@1.0.13: {}
-
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -15029,8 +14824,6 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  iterate-object@1.3.4: {}
 
   jackspeak@3.4.3:
     dependencies:
@@ -16004,8 +15797,6 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  noop6@1.0.9: {}
-
   normalize-path@1.0.0: {}
 
   normalize-path@3.0.0: {}
@@ -16037,10 +15828,6 @@ snapshots:
       next: 16.1.5(@babel/core@7.28.5)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   nwsapi@2.2.7: {}
-
-  obj-def@1.0.9:
-    dependencies:
-      deffy: 2.2.4
 
   object-assign@4.1.1: {}
 
@@ -16191,16 +15978,7 @@ snapshots:
 
   parse-passwd@1.0.0: {}
 
-  parse5-htmlparser2-tree-adapter@7.0.0:
-    dependencies:
-      domhandler: 5.0.3
-      parse5: 7.1.2
-
   parse5@6.0.1: {}
-
-  parse5@7.1.2:
-    dependencies:
-      entities: 4.5.0
 
   parseurl@1.3.3: {}
 
@@ -16447,8 +16225,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   psl@1.9.0: {}
 
@@ -16825,8 +16601,6 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
-  regex-escape@3.4.10: {}
-
   regexp.prototype.flags@1.5.3:
     dependencies:
       call-bind: 1.0.7
@@ -16994,25 +16768,6 @@ snapshots:
       object-assign: 4.1.1
 
   scheduler@0.27.0: {}
-
-  scrape-it-core@1.0.0:
-    dependencies:
-      cheerio: 1.0.0-rc.12
-      err: 2.1.12
-      is-empty-obj: 1.0.13
-      iterate-object: 1.3.4
-      obj-def: 1.0.9
-      typpy: 2.3.13
-
-  scrape-it@6.1.2(debug@4.4.1):
-    dependencies:
-      '@types/cheerio': 0.22.35
-      assured: 1.0.15
-      cheerio-req: 2.0.0(debug@4.4.1)
-      scrape-it-core: 1.0.0
-      typpy: 2.3.13
-    transitivePeerDependencies:
-      - debug
 
   screenfull@5.2.0: {}
 
@@ -17278,8 +17033,6 @@ snapshots:
   slash@3.0.0: {}
 
   slash@4.0.0: {}
-
-  sliced@1.0.1: {}
 
   slugify@1.6.6: {}
 
@@ -17746,10 +17499,6 @@ snapshots:
       is-typedarray: 1.0.0
 
   typescript@5.9.2: {}
-
-  typpy@2.3.13:
-    dependencies:
-      function.name: 1.0.13
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Goal

GitHub no longer renders the repository contributor count in the static HTML for the repo homepage; that number is loaded client-side, so our previous approach in `fetchContributorCount` (scraping `github.com/{owner}/{repo}` with `scrape-it`) no longer finds the counter and fails.

This change **stops scraping** and uses the **official REST API** instead: [`GET /repos/{owner}/{repo}/contributors`](https://docs.github.com/en/rest/repos/repos#list-repository-contributors). The API does not return a total in the JSON body, so we use **pagination metadata**: a single request with `per_page=1` (and `anon=true` so anonymous contributors are included), then read the **`Link` header** and parse `rel="last"` to get the `page=` query value, which equals the contributor count when each page holds one contributor. If there is only one page (or no `rel="last"`), we fall back to the length of the returned array (covers 0 or 1 contributor).

**Other changes:** removed the `scrape-it` dependency from `@repo/api` and refreshed `pnpm-lock.yaml`. Added a manual test for `bestofjs/bestofjs` with a bounded contributor range to sanity-check the new implementation against a known repo.

## How to test

```sh
bun test packages/api/src/github/github-client.test.ts  
```

```
packages/api/src/github/github-client.test.ts:
✓ GitHub API client > Moved repo [770.65ms]
✓ GitHub API client > Repo fallback [603.75ms]
✓ GitHub API client > Repo info [820.74ms]
✓ GitHub API client > Repo description [1312.83ms]
✓ GitHub API client > Contributor count [678.67ms]
✓ GitHub API client > Contributor count (bestofjs/bestofjs) [462.41ms]
✓ GitHub API client > User info [347.92ms]
```

## Screenshots

<img width="1149" height="940" alt="image" src="https://github.com/user-attachments/assets/c6a454d6-8531-4a40-8fe7-91a6aa5431ac" />
