### PR TITLE
Migration trends table • Task 2/7 • Setup `project_trends` table

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,6 +11,7 @@
     "daily-update-package-data": "dotenv -e ../../.env tsx ./src/cli.ts update-package-data -- --logLevel 3 --concurrency 5",
     "daily-update-bundle-size": "dotenv -e ../../.env tsx ./src/cli.ts update-bundle-size -- --logLevel 3",
     "daily-update-repo-trends": "dotenv -e ../../.env tsx ./src/cli.ts update-repo-trends -- --logLevel 3 --concurrency 5",
+    "daily-update-trends": "dotenv -e ../../.env tsx ./src/cli.ts daily-update-trends -- --logLevel 3 --concurrency 5",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch",
     "lint": "biome check ./src",

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -6,6 +6,7 @@ import { createTaskRunner } from "./task-runner";
 import type { Task } from "./task-types";
 import { buildMonthlyRankingsTask } from "./tasks/build-monthly-rankings.task";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
+import { cleanupRepoTrendsTask } from "./tasks/cleanup-repo-trends.task";
 import {
   helloWorldHallOfFameTask,
   helloWorldProjectsTask,
@@ -22,6 +23,7 @@ import { updateBundleSizeTask } from "./tasks/update-bundle-size.task";
 import { updateGitHubDataTask } from "./tasks/update-github-data.task";
 import { updateHallOfFameTask } from "./tasks/update-hall-of-fame.task";
 import { updatePackageDataTask } from "./tasks/update-package-data.task";
+import { updateProjectTrendsTask } from "./tasks/update-project-trends.task";
 import { updateRepoTrendsTask } from "./tasks/update-repo-trends.task";
 
 const commands = [
@@ -37,7 +39,9 @@ const commands = [
   updatePackageDataTask,
   updateHallOfFameTask,
   updateBundleSizeTask,
+  cleanupRepoTrendsTask,
   updateRepoTrendsTask,
+  updateProjectTrendsTask,
   buildMonthlyRankingsTask,
   buildRisingStarsTask,
   cleanupRisingStars,
@@ -62,9 +66,27 @@ const staticApiDailyTask = command(
   },
 );
 
+const dailyUpdateTrendsTask = command(
+  {
+    name: "daily-update-trends",
+    description:
+      "Daily trends pipeline: cleanup → repo_trends Pass 1 → project_trends Pass 2. Early-exit on failure; previous day's data is retained.",
+    flags: sharedFlags,
+  },
+  (argv) => {
+    const tasks: Task<any>[] = [
+      cleanupRepoTrendsTask,
+      updateRepoTrendsTask,
+      updateProjectTrendsTask,
+    ];
+    const runner = createTaskRunner(tasks);
+    runner.run(argv.flags);
+  },
+);
+
 cli({
   name: "bestofjs-cli",
-  commands: [staticApiDailyTask, ...commands],
+  commands: [staticApiDailyTask, dailyUpdateTrendsTask, ...commands],
 });
 
 function getCommand(task: Task<any>) {

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -70,7 +70,7 @@ const dailyUpdateTrendsTask = command(
   {
     name: "daily-update-trends",
     description:
-      "Daily trends pipeline: cleanup → repo_trends Pass 1 → project_trends Pass 2. Early-exit on failure; previous day's data is retained.",
+      "Daily trends pipeline: cleanup → repo_trends Pass 1 → project_trends Pass 2. Stops if a task throws; per-row errors are logged and the row keeps yesterday's value.",
     flags: sharedFlags,
   },
   (argv) => {

--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -59,7 +59,17 @@ export function createTaskRunner(tasks: Task<RawFlags | undefined>[]) {
             const context = createTaskContext(db);
 
             const result = await task.run(context, taskFlags);
-            logger.success("Task", task.name, "completed", result.meta);
+            const errorCount = Number(result.meta?.error ?? 0);
+            if (errorCount > 0) {
+              logger.warn(
+                "Task",
+                task.name,
+                "completed with errors",
+                result.meta,
+              );
+            } else {
+              logger.success("Task", task.name, "completed", result.meta);
+            }
           }
           resolve(true);
         });

--- a/apps/backend/src/tasks/cleanup-repo-trends.task.ts
+++ b/apps/backend/src/tasks/cleanup-repo-trends.task.ts
@@ -1,0 +1,51 @@
+import { schema } from "@repo/db";
+import { count, ne, notInArray } from "@repo/db/drizzle";
+
+import { createTask } from "@/task-runner";
+
+export const cleanupRepoTrendsTask = createTask({
+  name: "cleanup-repo-trends",
+  description:
+    "Delete repo_trends rows for repos linked only to deprecated projects. Runs daily before update-repo-trends.",
+  run: async ({ db, logger, dryRun }) => {
+    const reposWithActiveProject = db
+      .select({ repoId: schema.projects.repoId })
+      .from(schema.projects)
+      .where(ne(schema.projects.status, "deprecated"));
+
+    const deprecatedOnlyFilter = notInArray(
+      schema.repoTrends.repoId,
+      reposWithActiveProject,
+    );
+
+    if (dryRun) {
+      const [row] = await db
+        .select({ wouldDelete: count() })
+        .from(schema.repoTrends)
+        .where(deprecatedOnlyFilter);
+
+      const n = Number(row?.wouldDelete ?? 0);
+      logger.info(
+        `Dry run: would delete ${n} repo_trends row(s) for deprecated-only repos`,
+      );
+      return {
+        data: null,
+        meta: { deleted: 0, wouldDelete: n },
+      };
+    }
+
+    const result = await db
+      .delete(schema.repoTrends)
+      .where(deprecatedOnlyFilter);
+
+    const deleted = result.rowCount ?? 0;
+    logger.info(
+      `Deleted ${deleted} repo_trends row(s) for deprecated-only repos`,
+    );
+
+    return {
+      data: null,
+      meta: { deleted },
+    };
+  },
+});

--- a/apps/backend/src/tasks/update-project-trends.task.ts
+++ b/apps/backend/src/tasks/update-project-trends.task.ts
@@ -1,0 +1,93 @@
+import { schema } from "@repo/db";
+import {
+  computeRelevanceScore,
+  computeUsageScore,
+} from "@repo/db/project-trends";
+import type { ProjectDetails } from "@repo/db/projects";
+
+import { createTask } from "@/task-runner";
+
+export const updateProjectTrendsTask = createTask({
+  name: "update-project-trends",
+  description:
+    "Compute project-level usage and relevance scores from packages + repo_trends; upsert into project_trends. Runs daily after update-repo-trends.",
+  run: async ({ db, processProjects, logger, dryRun }) => {
+    const repoTrendsRows = await db
+      .select({
+        repoId: schema.repoTrends.repoId,
+        popularityScore: schema.repoTrends.popularityScore,
+        activityScore: schema.repoTrends.activityScore,
+      })
+      .from(schema.repoTrends);
+
+    const repoTrendsByRepoId = new Map(
+      repoTrendsRows.map((r) => [
+        r.repoId,
+        { popularityScore: r.popularityScore, activityScore: r.activityScore },
+      ]),
+    );
+    logger.info(`Loaded ${repoTrendsByRepoId.size} repo_trends rows`);
+
+    return await processProjects(async (project) => {
+      const primaryPackage = pickPrimaryPackage(project.packages);
+      const monthlyDownloads = primaryPackage?.monthlyDownloads ?? null;
+      const usageScore = computeUsageScore(monthlyDownloads);
+
+      const repoTrend = repoTrendsByRepoId.get(project.repoId);
+      const popularityScore = repoTrend?.popularityScore ?? 0;
+      const activityScore = repoTrend?.activityScore ?? 0;
+
+      const relevanceScore = computeRelevanceScore({
+        popularityScore,
+        activityScore,
+        usageScore: primaryPackage ? usageScore : undefined,
+        isDeprecated: project.status === "deprecated",
+      });
+
+      const recordData = {
+        projectId: project.id,
+        packageName: primaryPackage?.name ?? null,
+        monthlyDownloads,
+        usageScore,
+        relevanceScore,
+      };
+
+      if (!dryRun) {
+        await db
+          .insert(schema.projectTrends)
+          .values(recordData)
+          .onConflictDoUpdate({
+            target: schema.projectTrends.projectId,
+            set: { ...recordData, updatedAt: new Date() },
+          });
+      }
+
+      logger.info(
+        dryRun
+          ? "project_trends scores (dry run, no write)"
+          : "project_trends upserted",
+        {
+          slug: project.slug,
+          packageName: recordData.packageName,
+          monthlyDownloads,
+          usageScore,
+          relevanceScore,
+        },
+      );
+
+      return {
+        data: null,
+        meta: { updated: !dryRun, kept: relevanceScore >= 0 },
+      };
+    });
+  },
+});
+
+function pickPrimaryPackage(packages: ProjectDetails["packages"]) {
+  if (packages.length === 0) return null;
+  return packages.reduce((best, current) => {
+    const bestDownloads = best.monthlyDownloads ?? 0;
+    const currentDownloads = current.monthlyDownloads ?? 0;
+    return currentDownloads > bestDownloads ? current : best;
+  });
+}

--- a/apps/backend/src/tasks/update-project-trends.task.ts
+++ b/apps/backend/src/tasks/update-project-trends.task.ts
@@ -62,7 +62,7 @@ export const updateProjectTrendsTask = createTask({
           });
       }
 
-      logger.info(
+      logger.debug(
         dryRun
           ? "project_trends scores (dry run, no write)"
           : "project_trends upserted",

--- a/packages/db/drizzle/0011_simple_peter_quill.sql
+++ b/packages/db/drizzle/0011_simple_peter_quill.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "project_trends" (
+	"project_id" text PRIMARY KEY NOT NULL,
+	"package_name" text,
+	"monthly_downloads" integer,
+	"usage_score" real NOT NULL,
+	"relevance_score" real NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "project_trends" ADD CONSTRAINT "project_trends_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "project_trends_usage_score_idx" ON "project_trends" USING btree ("usage_score");--> statement-breakpoint
+CREATE INDEX "project_trends_relevance_score_idx" ON "project_trends" USING btree ("relevance_score");--> statement-breakpoint
+CREATE VIEW "public"."project_trends_view" AS (select "project_trends"."project_id", "projects"."slug", "projects"."name", "projects"."status", "repos"."owner" || '/' || "repos"."name" as "full_name", "project_trends"."package_name", "project_trends"."monthly_downloads", "project_trends"."usage_score", "project_trends"."relevance_score", "project_trends"."updated_at" from "project_trends" inner join "projects" on "project_trends"."project_id" = "projects"."id" inner join "repos" on "projects"."repoId" = "repos"."id");

--- a/packages/db/drizzle/meta/0011_snapshot.json
+++ b/packages/db/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1209 @@
+{
+  "id": "190d1bb1-bd82-49db-bab7-4906f7a605cc",
+  "prevId": "003ac63b-ec57-4dc9-86a1-c81f2dc2d9a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gzip": {
+          "name": "gzip",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundles_name_packages_name_fk": {
+          "name": "bundles_name_packages_name_fk",
+          "tableFrom": "bundles",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_featured_projects": {
+      "name": "daily_featured_projects",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_slugs": {
+          "name": "project_slugs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hall_of_fame": {
+      "name": "hall_of_fame",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers": {
+          "name": "followers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "npm_username": {
+          "name": "npm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "npm_package_count": {
+          "name": "npm_package_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hall_of_fame_to_projects": {
+      "name": "hall_of_fame_to_projects",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hall_of_fame_to_projects_username_hall_of_fame_username_fk": {
+          "name": "hall_of_fame_to_projects_username_hall_of_fame_username_fk",
+          "tableFrom": "hall_of_fame_to_projects",
+          "tableTo": "hall_of_fame",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hall_of_fame_to_projects_project_id_projects_id_fk": {
+          "name": "hall_of_fame_to_projects_project_id_projects_id_fk",
+          "tableFrom": "hall_of_fame_to_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hall_of_fame_to_projects_username_project_id_pk": {
+          "name": "hall_of_fame_to_projects_username_project_id_pk",
+          "columns": [
+            "username",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "devDependencies": {
+          "name": "devDependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deprecated": {
+          "name": "deprecated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_project_id_projects_id_fk": {
+          "name": "packages_project_id_projects_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_trends": {
+      "name": "project_trends",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_downloads": {
+          "name": "monthly_downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_score": {
+          "name": "usage_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_trends_usage_score_idx": {
+          "name": "project_trends_usage_score_idx",
+          "columns": [
+            {
+              "expression": "usage_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_trends_relevance_score_idx": {
+          "name": "project_trends_relevance_score_idx",
+          "columns": [
+            {
+              "expression": "relevance_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trends_project_id_projects_id_fk": {
+          "name": "project_trends_project_id_projects_id_fk",
+          "tableFrom": "project_trends",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_url": {
+          "name": "override_url",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_path": {
+          "name": "package_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_repoId_repos_id_fk": {
+          "name": "projects_repoId_repos_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repoId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_to_tags": {
+      "name": "projects_to_tags",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_to_tags_project_id_projects_id_fk": {
+          "name": "projects_to_tags_project_id_projects_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_to_tags_tag_id_tags_id_fk": {
+          "name": "projects_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "projects_to_tags_project_id_tag_id_pk": {
+          "name": "projects_to_tags_project_id_tag_id_pk",
+          "columns": [
+            "project_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_trends": {
+      "name": "repo_trends",
+      "schema": "",
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily": {
+          "name": "daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly": {
+          "name": "weekly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly": {
+          "name": "monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarterly": {
+          "name": "quarterly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yearly": {
+          "name": "yearly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity_score": {
+          "name": "popularity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_score": {
+          "name": "activity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repo_trends_popularity_score_idx": {
+          "name": "repo_trends_popularity_score_idx",
+          "columns": [
+            {
+              "expression": "popularity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_trends_activity_score_idx": {
+          "name": "repo_trends_activity_score_idx",
+          "columns": [
+            {
+              "expression": "activity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_trends_daily_idx": {
+          "name": "repo_trends_daily_idx",
+          "columns": [
+            {
+              "expression": "daily",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_trends_stars_idx": {
+          "name": "repo_trends_stars_idx",
+          "columns": [
+            {
+              "expression": "stars",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_trends_repo_id_repos_id_fk": {
+          "name": "repo_trends_repo_id_repos_id_fk",
+          "tableFrom": "repo_trends",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repos": {
+      "name": "repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stargazers_count": {
+          "name": "stargazers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contributor_count": {
+          "name": "contributor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "name_owner_index": {
+          "name": "name_owner_index",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.snapshots": {
+      "name": "snapshots",
+      "schema": "",
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "months": {
+          "name": "months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "snapshots_repo_id_repos_id_fk": {
+          "name": "snapshots_repo_id_repos_id_fk",
+          "tableFrom": "snapshots",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "snapshots_repo_id_year_pk": {
+          "name": "snapshots_repo_id_year_pk",
+          "columns": [
+            "repo_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_code_unique": {
+          "name": "tags_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.project_trends_view": {
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_downloads": {
+          "name": "monthly_downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_score": {
+          "name": "usage_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "definition": "select \"project_trends\".\"project_id\", \"projects\".\"slug\", \"projects\".\"name\", \"projects\".\"status\", \"repos\".\"owner\" || '/' || \"repos\".\"name\" as \"full_name\", \"project_trends\".\"package_name\", \"project_trends\".\"monthly_downloads\", \"project_trends\".\"usage_score\", \"project_trends\".\"relevance_score\", \"project_trends\".\"updated_at\" from \"project_trends\" inner join \"projects\" on \"project_trends\".\"project_id\" = \"projects\".\"id\" inner join \"repos\" on \"projects\".\"repoId\" = \"repos\".\"id\"",
+      "name": "project_trends_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.repo_trends_view": {
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily": {
+          "name": "daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly": {
+          "name": "weekly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly": {
+          "name": "monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarterly": {
+          "name": "quarterly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yearly": {
+          "name": "yearly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity_score": {
+          "name": "popularity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_score": {
+          "name": "activity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "definition": "select \"repo_trends\".\"repo_id\", \"repos\".\"owner\" || '/' || \"repos\".\"name\" as \"full_name\", \"repo_trends\".\"stars\", \"repo_trends\".\"daily\", \"repo_trends\".\"weekly\", \"repo_trends\".\"monthly\", \"repo_trends\".\"quarterly\", \"repo_trends\".\"yearly\", \"repo_trends\".\"popularity_score\", \"repo_trends\".\"activity_score\", \"repo_trends\".\"updated_at\" from \"repo_trends\" inner join \"repos\" on \"repo_trends\".\"repo_id\" = \"repos\".\"id\"",
+      "name": "repo_trends_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777980955503,
       "tag": "0010_condemned_doctor_strange",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777989340517,
+      "tag": "0011_simple_peter_quill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,6 +19,7 @@
     "./constants": "./src/constants.ts",
     "./projects": "./src/projects/index.ts",
     "./shared-schemas": "./src/shared-schemas.ts",
+    "./project-trends": "./src/project-trends/index.ts",
     "./repo-trends": "./src/repo-trends/index.ts",
     "./snapshots": "./src/snapshots/index.ts",
     "./tags": "./src/tags/index.ts",

--- a/packages/db/src/project-trends/index.ts
+++ b/packages/db/src/project-trends/index.ts
@@ -1,0 +1,1 @@
+export * from "./scoring";

--- a/packages/db/src/project-trends/scoring.test.ts
+++ b/packages/db/src/project-trends/scoring.test.ts
@@ -1,0 +1,119 @@
+import { computeRelevanceScore, computeUsageScore } from "./scoring";
+import { describe, expect, test } from "bun:test";
+
+describe("computeUsageScore", () => {
+  test("anchor: 10M downloads → 100", () => {
+    expect(computeUsageScore(10_000_000)).toBeCloseTo(100, 6);
+  });
+
+  test("anchor: 1M downloads → 80", () => {
+    expect(computeUsageScore(1_000_000)).toBeCloseTo(80, 6);
+  });
+
+  test("anchor: 100k downloads → 60", () => {
+    expect(computeUsageScore(100_000)).toBeCloseTo(60, 6);
+  });
+
+  test("anchor: 10k downloads → 40", () => {
+    expect(computeUsageScore(10_000)).toBeCloseTo(40, 6);
+  });
+
+  test("clamps below 100 floor (no/zero downloads → 0)", () => {
+    expect(computeUsageScore(undefined)).toBe(0);
+    expect(computeUsageScore(null)).toBe(0);
+    expect(computeUsageScore(0)).toBe(0);
+    expect(computeUsageScore(50)).toBe(0); // below 100, clamped to 0
+  });
+
+  test("clamps above 10M ceiling (>10M → 100)", () => {
+    expect(computeUsageScore(100_000_000)).toBe(100);
+    expect(computeUsageScore(1_000_000_000)).toBe(100);
+  });
+
+  test("monotonic — more downloads ranks higher", () => {
+    const a = computeUsageScore(50_000);
+    const b = computeUsageScore(500_000);
+    const c = computeUsageScore(5_000_000);
+    expect(a).toBeLessThan(b);
+    expect(b).toBeLessThan(c);
+  });
+});
+
+describe("computeRelevanceScore", () => {
+  test("with package: weighted 0.5 / 0.25 / 0.25", () => {
+    const score = computeRelevanceScore({
+      popularityScore: 100,
+      activityScore: 100,
+      usageScore: 100,
+    });
+    expect(score).toBeCloseTo(100, 6);
+  });
+
+  test("with package: arithmetic check", () => {
+    // 80 * 0.5 + 60 * 0.25 + 40 * 0.25 = 40 + 15 + 10 = 65
+    const score = computeRelevanceScore({
+      popularityScore: 80,
+      activityScore: 60,
+      usageScore: 40,
+    });
+    expect(score).toBeCloseTo(65, 6);
+  });
+
+  test("no package: weighted 0.65 / 0.35", () => {
+    // 80 * 0.65 + 60 * 0.35 = 52 + 21 = 73
+    const score = computeRelevanceScore({
+      popularityScore: 80,
+      activityScore: 60,
+    });
+    expect(score).toBeCloseTo(73, 6);
+  });
+
+  test("deprecated malus is exactly -20", () => {
+    const inputs = {
+      popularityScore: 50,
+      activityScore: 50,
+      usageScore: 50,
+    } as const;
+    const active = computeRelevanceScore(inputs);
+    const deprecated = computeRelevanceScore({ ...inputs, isDeprecated: true });
+    expect(active - deprecated).toBeCloseTo(20, 6);
+  });
+
+  test("deprecated with strong NPM usage clears the floor (≥ 0)", () => {
+    // 10M downloads → usage 100, no popularity/activity, deprecated
+    const score = computeRelevanceScore({
+      popularityScore: 0,
+      activityScore: 0,
+      usageScore: 100,
+      isDeprecated: true,
+    });
+    expect(score).toBeGreaterThanOrEqual(0); // 0 + 0 + 25 - 20 = 5
+  });
+
+  test("deprecated with no signal falls below the floor", () => {
+    const score = computeRelevanceScore({
+      popularityScore: 0,
+      activityScore: 0,
+      usageScore: 0,
+      isDeprecated: true,
+    });
+    expect(score).toBeLessThan(0);
+  });
+
+  test("usageScore=0 still counts as 'has package' (0 weight, not skipped)", () => {
+    // hasPackage path: 80*0.5 + 60*0.25 + 0*0.25 = 40 + 15 = 55
+    const withZero = computeRelevanceScore({
+      popularityScore: 80,
+      activityScore: 60,
+      usageScore: 0,
+    });
+    // no-package path: 80*0.65 + 60*0.35 = 52 + 21 = 73
+    const withoutPkg = computeRelevanceScore({
+      popularityScore: 80,
+      activityScore: 60,
+    });
+    expect(withZero).toBeCloseTo(55, 6);
+    expect(withoutPkg).toBeCloseTo(73, 6);
+    expect(withZero).toBeLessThan(withoutPkg);
+  });
+});

--- a/packages/db/src/project-trends/scoring.ts
+++ b/packages/db/src/project-trends/scoring.ts
@@ -1,0 +1,40 @@
+/**
+ * Log10 of monthly downloads, scaled into 0–100. Used as the sort key for "most used".
+ *
+ * score = max(0, min(100, (log10(downloads) - 2) * 20))
+ *
+ * Anchors: 100 downloads → 0, 10k → 40, 100k → 60, 1M → 80, 10M → 100.
+ * No or zero downloads → 0.
+ */
+export function computeUsageScore(monthlyDownloads: number | null | undefined) {
+  if (!monthlyDownloads || monthlyDownloads <= 0) return 0;
+  const raw = (Math.log10(monthlyDownloads) - 2) * 20;
+  return Math.max(0, Math.min(100, raw));
+}
+
+/**
+ * Weighted blend of popularity + activity + (usage when a package is linked),
+ * with a -20 malus for deprecated projects. Used only as a `WHERE` filter
+ * (`relevance_score >= 0`), never as an `ORDER BY` key.
+ *
+ *   with package:    0.50 * popularity + 0.25 * activity + 0.25 * usage
+ *   no package:      0.65 * popularity + 0.35 * activity
+ *   minus 20 if deprecated.
+ */
+export function computeRelevanceScore({
+  popularityScore,
+  activityScore,
+  usageScore,
+  isDeprecated = false,
+}: {
+  popularityScore: number;
+  activityScore: number;
+  usageScore?: number;
+  isDeprecated?: boolean;
+}) {
+  const hasPackage = typeof usageScore === "number";
+  const blend = hasPackage
+    ? popularityScore * 0.5 + activityScore * 0.25 + usageScore * 0.25
+    : popularityScore * 0.65 + activityScore * 0.35;
+  return isDeprecated ? blend - 20 : blend;
+}

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -2,6 +2,8 @@ export * from "./bundles";
 export * from "./daily-featured-projects";
 export * from "./hall-of-fame";
 export * from "./packages";
+export * from "./project-trends";
+export * from "./project-trends-view";
 export * from "./projects";
 export * from "./repo-trends";
 export * from "./repo-trends-view";

--- a/packages/db/src/schema/project-trends-view.ts
+++ b/packages/db/src/schema/project-trends-view.ts
@@ -1,0 +1,27 @@
+import { eq, sql } from "drizzle-orm";
+import { pgView } from "drizzle-orm/pg-core";
+
+import { projectTrends } from "./project-trends";
+import { projects } from "./projects";
+import { repos } from "./repos";
+
+export const projectTrendsView = pgView("project_trends_view").as((qb) =>
+  qb
+    .select({
+      projectId: projectTrends.projectId,
+      slug: projects.slug,
+      name: projects.name,
+      status: projects.status,
+      fullName: sql<string>`${repos.owner} || '/' || ${repos.name}`.as(
+        "full_name",
+      ),
+      packageName: projectTrends.packageName,
+      monthlyDownloads: projectTrends.monthlyDownloads,
+      usageScore: projectTrends.usageScore,
+      relevanceScore: projectTrends.relevanceScore,
+      updatedAt: projectTrends.updatedAt,
+    })
+    .from(projectTrends)
+    .innerJoin(projects, eq(projectTrends.projectId, projects.id))
+    .innerJoin(repos, eq(projects.repoId, repos.id)),
+);

--- a/packages/db/src/schema/project-trends.ts
+++ b/packages/db/src/schema/project-trends.ts
@@ -1,0 +1,40 @@
+import { relations } from "drizzle-orm";
+import {
+  index,
+  integer,
+  pgTable,
+  real,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+import { projects } from "./projects";
+
+/**
+ * Per-project trend cache: primary package, download signal, and heuristic scores, upserted daily by backend tasks.
+ * Derived data for listings/search—not canonical project metadata.
+ */
+export const projectTrends = pgTable(
+  "project_trends",
+  {
+    projectId: text("project_id")
+      .primaryKey()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    packageName: text("package_name"),
+    monthlyDownloads: integer("monthly_downloads"),
+    usageScore: real("usage_score").notNull(), // heuristic: NPM monthly downloads scale
+    relevanceScore: real("relevance_score").notNull(), // heuristic: blend of popularity/activity/usage; listings use >= 0, search may not
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("project_trends_usage_score_idx").on(table.usageScore),
+    index("project_trends_relevance_score_idx").on(table.relevanceScore),
+  ],
+);
+
+export const projectTrendsRelations = relations(projectTrends, ({ one }) => ({
+  project: one(projects, {
+    fields: [projectTrends.projectId],
+    references: [projects.id],
+  }),
+}));

--- a/packages/db/src/schema/repo-trends.ts
+++ b/packages/db/src/schema/repo-trends.ts
@@ -10,6 +10,10 @@ import {
 
 import { repos } from "./repos";
 
+/**
+ * Per-repo trend cache: star counts, snapshot deltas, and heuristic scores, upserted daily by backend tasks.
+ * Derived data for fast queries—not canonical repo metadata.
+ */
 export const repoTrends = pgTable(
   "repo_trends",
   {
@@ -22,8 +26,8 @@ export const repoTrends = pgTable(
     monthly: integer("monthly"),
     quarterly: integer("quarterly"),
     yearly: integer("yearly"),
-    popularityScore: real("popularity_score").notNull(),
-    activityScore: real("activity_score").notNull(),
+    popularityScore: real("popularity_score").notNull(), // heuristic: star momentum (from deltas)
+    activityScore: real("activity_score").notNull(), // heuristic: maintenance / recency + contributors
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
   (table) => [


### PR DESCRIPTION
## Goal

Fix #423 

Implement PRD step 2 of `replace-static-api-with-db`: introduce and wire the DB-backed trends cache foundation so daily jobs can persist repo/project trend signals and expose them for upcoming query migration steps.

## Main changes

- Added the `project_trends` data model and migration artifacts, alongside schema exports needed for DB access.
- Introduced pure scoring utilities for popularity/activity/usage/relevance so trend computation logic is centralized and testable.
- Added backend daily-task wiring for the step-2 flow:
  - cleanup of obsolete repo-trend rows
  - per-repo trend computation/upsert pass
  - per-project trend computation/upsert pass


## How to test

```
❯ bun run apps/backend/src/cli.ts update-repo-trends

 ╭─────────────────────────────────────────────────────╮
 │                                                     │
 │  Running task 1/1 "update-repo-trends" logLevel: 3  │
 │                                                     │
 ╰─────────────────────────────────────────────────────╯

ℹ Finding ids of repos to process...                                                                                                                                          3:40:12 PM
◐ Processing 3279 repo(s)...                                                                                                                                                   3:40:12 PM
ℹ Processed 3279 repo(s) in 26.2s (Avg: 8ms)                                                                                                                                  3:40:38 PM
✔ Task update-repo-trends completed { updated: 3279 }  
```


## Screenshots

<img width="1477" height="625" alt="image" src="https://github.com/user-attachments/assets/b2629522-defd-4bb2-9ba2-da314eeb19e0" />