### PR TITLE
Add update-trends workflow

### DIFF
--- a/.github/workflows/update-package-data.yml
+++ b/.github/workflows/update-package-data.yml
@@ -1,7 +1,7 @@
 name: Update Package Data
 on:
   schedule:
-    - cron: "0 23 * * *"
+    - cron: "0 19 * * *"
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/update-trends.yml
+++ b/.github/workflows/update-trends.yml
@@ -1,0 +1,49 @@
+name: Update Trends
+
+on:
+  workflow_run:
+    workflows: ["Update GitHub Data"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level: 3 => info, 4 => debug"
+        required: true
+        default: 3
+        type: choice
+        options:
+          - 3
+          - 4
+      limit:
+        description: "Number of projects to process (0 = all)"
+        required: false
+        type: number
+        default: 0
+      skip:
+        description: "Number of projects to skip"
+        required: false
+        type: number
+        default: 0
+      concurrency:
+        description: "Number of projects to process concurrently"
+        required: false
+        type: number
+        default: 5
+
+env:
+  POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+
+jobs:
+  update-trends:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: ./.github/tooling/github-actions/install
+      - name: Install Dependencies
+        shell: bash
+        run: pnpm -F backend... install
+      - name: Update Trends
+        run: pnpm -F backend daily-update-trends --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 5 }}


### PR DESCRIPTION
## Goal

Adds a GitHub Actions workflow that runs the daily trends pipeline (cleanup → repo_trends → project_trends) automatically after "Update GitHub Data" succeeds. Falls back to workflow_dispatch for manual runs. Without this, the `repo_trends` and `project_trends` tables were never populated in production.

Related: #429 and #430 that setup the two new tables.

Updated schedule:

- 19:00 UTC package data refreshes NPM fields
- 21:00 UTC GitHub data refreshes repo stars/snapshots
- Update Trends runs after GitHub data and sees both fresh package + GitHub inputs

## How to test

To be launched from GitHub Actions UI once merged!
