### PR TITLE
Migrate from @vercel/postgres and fix migration script

### DIFF
--- a/apps/web/src/app/api/featured-projects/route.ts
+++ b/apps/web/src/app/api/featured-projects/route.ts
@@ -1,4 +1,5 @@
 import { api } from "@/server/api-remote-json";
+import { findRandomFeaturedProjects } from "@/server/featured-projects";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -6,7 +7,10 @@ export async function GET(request: Request) {
   const limitParam = searchParams.get("limit");
   const skip = skipParam ? parseInt(skipParam) : 0;
   const limit = limitParam ? parseInt(limitParam) : 0;
-  const output = await api.projects.findRandomFeaturedProjects({ skip, limit });
+  const output = await findRandomFeaturedProjects(
+    api.projects.getProjectBySlug,
+    { skip, limit },
+  );
 
   return new Response(JSON.stringify(output), {
     status: 200,

--- a/apps/web/src/components/home/home-featured-projects.tsx
+++ b/apps/web/src/components/home/home-featured-projects.tsx
@@ -5,6 +5,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { api } from "@/server/api";
+import { findRandomFeaturedProjects } from "@/server/featured-projects";
 
 import { FeaturedProjectsClient } from "./home-featured-projects.client";
 
@@ -39,9 +40,9 @@ export async function FeaturedProjects({ numberOfProjectPerPage = 5 }: Props) {
 }
 
 async function fetchFeaturedProjects(numberOfProjectPerPage: number) {
-  const { projects, total } = await api.projects.findRandomFeaturedProjects({
-    skip: 0,
-    limit: numberOfProjectPerPage,
-  });
+  const { projects, total } = await findRandomFeaturedProjects(
+    api.projects.getProjectBySlug,
+    { skip: 0, limit: numberOfProjectPerPage },
+  );
   return { projects, total };
 }

--- a/apps/web/src/server/api-projects.tsx
+++ b/apps/web/src/server/api-projects.tsx
@@ -1,9 +1,6 @@
 import * as mingo from "mingo";
 import type { RawObject } from "mingo/types";
 
-import { db, schema } from "@repo/db";
-import { desc } from "@repo/db/drizzle";
-
 import {
   filterProjectsByQuery,
   getResultRelevantTags,
@@ -103,25 +100,6 @@ export function createProjectsAPI({ getData }: APIContext) {
         ? populate(projectsBySlug[slug])
         : undefined;
       return { project, lastUpdateDate };
-    },
-
-    async findRandomFeaturedProjects({
-      skip = 0,
-      limit = 5,
-    }: Pick<QueryParams, "skip" | "limit">) {
-      const { populate, projectsBySlug } = await getData();
-      const featuredProjectSlugsRecord =
-        await db.query.dailyFeaturedProjects.findFirst({
-          orderBy: desc(schema.dailyFeaturedProjects.createdAt),
-        });
-      const featuredProjectSlugs =
-        featuredProjectSlugsRecord?.projectSlugs || [];
-      const slugs = featuredProjectSlugs.slice(skip, skip + limit);
-      const projects = slugs
-        .map((slug) => projectsBySlug[slug])
-        .filter(Boolean)
-        .map(populate);
-      return { projects, total: featuredProjectSlugs.length };
     },
 
     async getStats() {

--- a/apps/web/src/server/featured-projects.ts
+++ b/apps/web/src/server/featured-projects.ts
@@ -1,0 +1,22 @@
+import { db, schema } from "@repo/db";
+import { desc } from "@repo/db/drizzle";
+
+type GetProjectBySlug = (
+  slug: string,
+) => Promise<{ project: BestOfJS.Project | undefined }>;
+
+export async function findRandomFeaturedProjects(
+  getProjectBySlug: GetProjectBySlug,
+  { skip = 0, limit = 5 }: { skip?: number; limit?: number } = {},
+) {
+  const record = await db.query.dailyFeaturedProjects.findFirst({
+    orderBy: desc(schema.dailyFeaturedProjects.createdAt),
+  });
+  const allSlugs = record?.projectSlugs ?? [];
+  const slugs = allSlugs.slice(skip, skip + limit);
+  const results = await Promise.all(slugs.map(getProjectBySlug));
+  const projects = results
+    .map((r) => r.project)
+    .filter((p): p is BestOfJS.Project => p !== undefined);
+  return { projects, total: allSlugs.length };
+}

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,5 +1,11 @@
 import type { Config } from "drizzle-kit";
 
+// drizzle-kit auto-detects the driver from installed packages in this order:
+// pg → postgres → @vercel/postgres → @neondatabase/serverless.
+// @neondatabase/serverless requires WebSocket and won't work with a local TCP
+// Postgres instance, so `postgres` is listed as a devDependency to ensure
+// drizzle-kit uses it instead for migrations in local development.
+
 const url = process.env.POSTGRES_URL;
 if (!url) {
   throw new Error("POSTGRES_URL not set");

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -31,7 +31,6 @@
     "@t3-oss/env-nextjs": "^0.13.8",
     "@types/debug": "catalog:",
     "@types/luxon": "^3.7.1",
-    "@vercel/postgres": "^0.10.0",
     "debug": "^4.4.1",
     "dotenv-cli": "catalog:",
     "drizzle-kit": "^0.31.4",
@@ -46,6 +45,7 @@
   },
   "devDependencies": {
     "@clack/prompts": "^0.11.0",
-    "@types/bun": "^1.2.21"
+    "@types/bun": "^1.2.21",
+    "postgres": "^3.4.9"
   }
 }

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,5 +1,3 @@
-// Setup to run locally with Vercel Postgres
-// Copied from https://vercel.com/docs/storage/vercel-postgres/local-development
 import { neonConfig } from "@neondatabase/serverless";
 
 if (process.env.VERCEL_ENV === "development") {
@@ -9,4 +7,4 @@ if (process.env.VERCEL_ENV === "development") {
   neonConfig.pipelineConnect = false;
 }
 
-export * from "@vercel/postgres";
+export * from "@neondatabase/serverless";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,6 +16,8 @@ const connectionString = process.env.POSTGRES_URL;
 if (!connectionString) throw new Error("POSTGRES_URL is not set");
 
 const pool = new Pool({ connectionString });
+pool.on("connect", () => debug("DB connected"));
+pool.on("remove", () => debug("DB disconnected"));
 
 export const db = drizzle(pool, {
   schema,
@@ -23,31 +25,11 @@ export const db = drizzle(pool, {
 });
 
 export async function runQuery(callback: (db: DB) => Promise<void>) {
-  const service = new NeonDbService();
-
   try {
-    await callback(service.db);
+    await callback(db);
   } catch (error) {
     console.error(error);
   } finally {
-    await service.disconnect();
-  }
-}
-
-class NeonDbService {
-  db: DB;
-
-  constructor() {
-    this.db = db;
-    pool.on("connect", () => {
-      debug("DB connected");
-    });
-    pool.on("remove", () => {
-      debug("DB disconnected");
-    });
-  }
-
-  disconnect() {
-    return pool.end();
+    await pool.end();
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,7 +1,8 @@
 import createDebug from "debug";
-import { drizzle } from "drizzle-orm/vercel-postgres";
+import { Pool } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-serverless";
 
-import { sql } from "./db";
+import "./db"; // applies neonConfig side effects before the pool is created
 import * as schema from "./schema";
 
 const debug = createDebug("db");
@@ -10,13 +11,15 @@ export * as schema from "./schema";
 
 export type DB = ReturnType<typeof drizzle<typeof schema>>;
 
-export const db = drizzle(sql, {
+const pool = new Pool({ connectionString: process.env.POSTGRES_URL });
+
+export const db = drizzle(pool, {
   schema,
   logger: process.env.ENABLE_SQL_LOGGING === "1",
 });
 
 export async function runQuery(callback: (db: DB) => Promise<void>) {
-  const service = new VercelPostgresService();
+  const service = new NeonDbService();
 
   try {
     await callback(service.db);
@@ -27,20 +30,20 @@ export async function runQuery(callback: (db: DB) => Promise<void>) {
   }
 }
 
-class VercelPostgresService {
+class NeonDbService {
   db: DB;
 
   constructor() {
     this.db = db;
-    sql.on("connect", () => {
-      debug("Vercel DB connected");
+    pool.on("connect", () => {
+      debug("DB connected");
     });
-    sql.on("remove", () => {
-      debug("Vercel DB disconnected");
+    pool.on("remove", () => {
+      debug("DB disconnected");
     });
   }
 
   disconnect() {
-    sql.end();
+    pool.end();
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,8 +1,9 @@
-import createDebug from "debug";
 import { Pool } from "@neondatabase/serverless";
+import createDebug from "debug";
 import { drizzle } from "drizzle-orm/neon-serverless";
 
 import "./db"; // applies neonConfig side effects before the pool is created
+
 import * as schema from "./schema";
 
 const debug = createDebug("db");

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,7 +12,10 @@ export * as schema from "./schema";
 
 export type DB = ReturnType<typeof drizzle<typeof schema>>;
 
-const pool = new Pool({ connectionString: process.env.POSTGRES_URL });
+const connectionString = process.env.POSTGRES_URL;
+if (!connectionString) throw new Error("POSTGRES_URL is not set");
+
+const pool = new Pool({ connectionString });
 
 export const db = drizzle(pool, {
   schema,
@@ -27,7 +30,7 @@ export async function runQuery(callback: (db: DB) => Promise<void>) {
   } catch (error) {
     console.error(error);
   } finally {
-    service.disconnect();
+    await service.disconnect();
   }
 }
 
@@ -45,6 +48,6 @@ class NeonDbService {
   }
 
   disconnect() {
-    pool.end();
+    return pool.end();
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,13 +445,13 @@ importers:
         version: 0.14.3
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(bufferutil@4.0.8)
+        version: 27.5.1
       jest-preview:
         specifier: ^0.3.1
-        version: 0.3.1(bufferutil@4.0.8)(postcss@8.5.11)
+        version: 0.3.1(postcss@8.5.11)
       jest-watch-typeahead:
         specifier: ^1.1.0
-        version: 1.1.0(jest@27.5.1(bufferutil@4.0.8))
+        version: 1.1.0(jest@27.5.1)
       msw:
         specifier: ^2.3.5
         version: 2.3.5(typescript@5.9.2)
@@ -589,7 +589,7 @@ importers:
         version: 5.1.3(typescript@5.9.2)(vite@5.4.14(@types/node@24.12.3)(lightningcss@1.30.2)(terser@5.19.2))
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.12.3)(jsdom@16.7.0(bufferutil@4.0.8))(lightningcss@1.30.2)(msw@2.12.0(@types/node@24.12.3)(typescript@5.9.2))(terser@5.19.2)
+        version: 2.1.9(@types/node@24.12.3)(jsdom@16.7.0)(lightningcss@1.30.2)(msw@2.12.0(@types/node@24.12.3)(typescript@5.9.2))(terser@5.19.2)
       zod:
         specifier: 'catalog:'
         version: 4.1.8
@@ -640,9 +640,6 @@ importers:
       '@types/luxon':
         specifier: ^3.7.1
         version: 3.7.1
-      '@vercel/postgres':
-        specifier: ^0.10.0
-        version: 0.10.0
       debug:
         specifier: ^4.4.1
         version: 4.4.1
@@ -654,7 +651,7 @@ importers:
         version: 0.31.4
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@vercel/postgres@0.10.0)(bun-types@1.2.21(@types/react@19.1.2))
+        version: 0.45.2(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(bun-types@1.2.21(@types/react@19.1.2))(postgres@3.4.9)
       es-toolkit:
         specifier: ^1.39.10
         version: 1.39.10
@@ -683,6 +680,9 @@ importers:
       '@types/bun':
         specifier: ^1.2.21
         version: 1.2.21(@types/react@19.1.2)
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
 
 packages:
 
@@ -4513,11 +4513,6 @@ packages:
   '@vercel/analytics@1.0.1':
     resolution: {integrity: sha512-Ux0c9qUfkcPqng3vrR0GTrlQdqNJ2JREn/2ydrVuKwM3RtMfF2mWX31Ijqo1opSjNAq6rK76PwtANw6kl6TAow==}
 
-  '@vercel/postgres@0.10.0':
-    resolution: {integrity: sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg==}
-    engines: {node: '>=18.14'}
-    deprecated: '@vercel/postgres is deprecated. If you are setting up a new database, you can choose an alternate storage solution from the Vercel Marketplace. If you had an existing Vercel Postgres database, it should have been migrated to Neon as a native Vercel integration. You can find more details and the guide to migrate to Neon''s SDKs here: https://neon.com/docs/guides/vercel-postgres-transition-guide'
-
   '@vitejs/plugin-react@2.2.0':
     resolution: {integrity: sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -4819,10 +4814,6 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  bufferutil@4.0.8:
-    resolution: {integrity: sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==}
-    engines: {node: '>=6.14.2'}
 
   bun-types@1.2.21:
     resolution: {integrity: sha512-sa2Tj77Ijc/NTLS0/Odjq/qngmEPZfbfnOERi0KRUYhT9R8M4VBioWVmMWE5GrYbKMc+5lVybXygLdibHaqVqw==}
@@ -7250,10 +7241,6 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-
   node-html-parser@5.4.2:
     resolution: {integrity: sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==}
 
@@ -7670,6 +7657,10 @@ packages:
 
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
+    engines: {node: '>=12'}
 
   prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -10931,7 +10922,7 @@ snapshots:
       jest-util: 28.1.3
       slash: 3.0.0
 
-  '@jest/core@27.5.1(bufferutil@4.0.8)':
+  '@jest/core@27.5.1':
     dependencies:
       '@jest/console': 27.5.1
       '@jest/reporters': 27.5.1
@@ -10945,13 +10936,13 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1(bufferutil@4.0.8)
+      jest-config: 27.5.1
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1(bufferutil@4.0.8)
+      jest-runner: 27.5.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -13088,14 +13079,6 @@ snapshots:
 
   '@vercel/analytics@1.0.1': {}
 
-  '@vercel/postgres@0.10.0':
-    dependencies:
-      '@neondatabase/serverless': 0.9.5
-      bufferutil: 4.0.8
-      ws: 8.18.0(bufferutil@4.0.8)
-    transitivePeerDependencies:
-      - utf-8-validate
-
   '@vitejs/plugin-react@2.2.0(vite@6.4.2(@types/node@24.12.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.19.2)(tsx@4.20.5)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.22.9
@@ -13463,10 +13446,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  bufferutil@4.0.8:
-    dependencies:
-      node-gyp-build: 4.8.4
 
   bun-types@1.2.21(@types/react@19.1.2):
     dependencies:
@@ -14042,12 +14021,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.2(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@vercel/postgres@0.10.0)(bun-types@1.2.21(@types/react@19.1.2)):
+  drizzle-orm@0.45.2(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(bun-types@1.2.21(@types/react@19.1.2))(postgres@3.4.9):
     optionalDependencies:
       '@neondatabase/serverless': 0.9.5
       '@types/pg': 8.11.6
-      '@vercel/postgres': 0.10.0
       bun-types: 1.2.21(@types/react@19.1.2)
+      postgres: 3.4.9
 
   dunder-proto@1.0.1:
     dependencies:
@@ -15235,16 +15214,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@27.5.1(bufferutil@4.0.8):
+  jest-cli@27.5.1:
     dependencies:
-      '@jest/core': 27.5.1(bufferutil@4.0.8)
+      '@jest/core': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 27.5.1(bufferutil@4.0.8)
+      jest-config: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -15256,7 +15235,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-config@27.5.1(bufferutil@4.0.8):
+  jest-config@27.5.1:
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 27.5.1
@@ -15268,13 +15247,13 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1(bufferutil@4.0.8)
+      jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
       jest-get-type: 27.5.1
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1(bufferutil@4.0.8)
+      jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.8
@@ -15314,7 +15293,7 @@ snapshots:
       jest-util: 27.5.1
       pretty-format: 27.5.1
 
-  jest-environment-jsdom@27.5.1(bufferutil@4.0.8):
+  jest-environment-jsdom@27.5.1:
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
@@ -15322,7 +15301,7 @@ snapshots:
       '@types/node': 22.4.0
       jest-mock: 27.5.1
       jest-util: 27.5.1
-      jsdom: 16.7.0(bufferutil@4.0.8)
+      jsdom: 16.7.0
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -15426,7 +15405,7 @@ snapshots:
     optionalDependencies:
       jest-resolve: 27.5.1
 
-  jest-preview@0.3.1(bufferutil@4.0.8)(postcss@8.5.11):
+  jest-preview@0.3.1(postcss@8.5.11):
     dependencies:
       '@svgr/core': 6.5.1
       camelcase: 6.3.0
@@ -15442,7 +15421,7 @@ snapshots:
       slash: 3.0.0
       string-hash: 1.1.3
       update-notifier: 5.1.0
-      ws: 8.18.0(bufferutil@4.0.8)
+      ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - postcss
@@ -15475,7 +15454,7 @@ snapshots:
       resolve.exports: 1.1.1
       slash: 3.0.0
 
-  jest-runner@27.5.1(bufferutil@4.0.8):
+  jest-runner@27.5.1:
     dependencies:
       '@jest/console': 27.5.1
       '@jest/environment': 27.5.1
@@ -15487,7 +15466,7 @@ snapshots:
       emittery: 0.8.1
       graceful-fs: 4.2.11
       jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1(bufferutil@4.0.8)
+      jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
       jest-haste-map: 27.5.1
       jest-leak-detector: 27.5.1
@@ -15590,11 +15569,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 27.5.1
 
-  jest-watch-typeahead@1.1.0(jest@27.5.1(bufferutil@4.0.8)):
+  jest-watch-typeahead@1.1.0(jest@27.5.1):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 27.5.1(bufferutil@4.0.8)
+      jest: 27.5.1
       jest-regex-util: 28.0.2
       jest-watcher: 28.1.3
       slash: 4.0.0
@@ -15628,11 +15607,11 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@27.5.1(bufferutil@4.0.8):
+  jest@27.5.1:
     dependencies:
-      '@jest/core': 27.5.1(bufferutil@4.0.8)
+      '@jest/core': 27.5.1
       import-local: 3.1.0
-      jest-cli: 27.5.1(bufferutil@4.0.8)
+      jest-cli: 27.5.1
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -15657,7 +15636,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@16.7.0(bufferutil@4.0.8):
+  jsdom@16.7.0:
     dependencies:
       abab: 2.0.6
       acorn: 8.14.0
@@ -15684,7 +15663,7 @@ snapshots:
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
-      ws: 7.5.9(bufferutil@4.0.8)
+      ws: 7.5.9
       xml-name-validator: 3.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -16146,8 +16125,6 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-gyp-build@4.8.4: {}
-
   node-html-parser@5.4.2:
     dependencies:
       css-select: 4.3.0
@@ -16517,6 +16494,8 @@ snapshots:
   postgres-interval@3.0.0: {}
 
   postgres-range@1.1.4: {}
+
+  postgres@3.4.9: {}
 
   prebuild-install@7.1.1:
     dependencies:
@@ -18121,7 +18100,7 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.6.1
 
-  vitest@2.1.9(@types/node@24.12.3)(jsdom@16.7.0(bufferutil@4.0.8))(lightningcss@1.30.2)(msw@2.12.0(@types/node@24.12.3)(typescript@5.9.2))(terser@5.19.2):
+  vitest@2.1.9(@types/node@24.12.3)(jsdom@16.7.0)(lightningcss@1.30.2)(msw@2.12.0(@types/node@24.12.3)(typescript@5.9.2))(terser@5.19.2):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(msw@2.12.0(@types/node@24.12.3)(typescript@5.9.2))(vite@5.4.14(@types/node@24.12.3)(lightningcss@1.30.2)(terser@5.19.2))
@@ -18145,7 +18124,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.3
-      jsdom: 16.7.0(bufferutil@4.0.8)
+      jsdom: 16.7.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -18291,13 +18270,9 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@7.5.9(bufferutil@4.0.8):
-    optionalDependencies:
-      bufferutil: 4.0.8
+  ws@7.5.9: {}
 
-  ws@8.18.0(bufferutil@4.0.8):
-    optionalDependencies:
-      bufferutil: 4.0.8
+  ws@8.18.0: {}
 
   xdg-basedir@4.0.0: {}
 


### PR DESCRIPTION
## Goal

\`@vercel/postgres\` is deprecated as mentioned on NPM.

Migration guide: https://neon.com/docs/guides/vercel-postgres-transition-guide

## Changes

- Replace \`@vercel/postgres\` with \`@neondatabase/serverless\` directly in \`src/db.ts\` and \`src/index.ts\`
- Switch from \`drizzle-orm/vercel-postgres\` to \`drizzle-orm/neon-serverless\` adapter
- Refactor \`packages/db/src/index.ts\`: remove \`NeonDbService\` class, attach pool listeners at module scope, validate \`POSTGRES_URL\` early, and make \`runQuery\` properly await disconnect

## Problem found: migration script broken after PNPM 11 upgrade

While working on this, we found that \`pnpm -F db migrate\` was already broken (before this PR) after the PNPM 11 upgrade (#433).

**Error:**

```
'@vercel/postgres' can only connect to remote Neon/Vercel Postgres/Supabase instances through a websocket
```

**Root cause:**

\`drizzle-kit\` auto-detects the Postgres driver from installed packages in this order: \`pg\` → \`postgres\` → \`@vercel/postgres\` → \`@neondatabase/serverless\`. Previously, \`postgres\` was available in \`@repo/db\`'s resolved context (hoisted from another package), so drizzle-kit used it to connect via direct TCP. After the PNPM 11 upgrade, stricter peer dependency resolution stopped hoisting \`postgres\` into \`@repo/db\`'s context. drizzle-kit fell back to \`@vercel/postgres\`, which requires a WebSocket connection and cannot connect to a plain local Docker Postgres instance.

The same issue would occur with \`@neondatabase/serverless\` (the replacement for \`@vercel/postgres\`) since it also requires WebSocket.

**Fix:**

Add \`postgres\` as an explicit \`devDependency\` of \`@repo/db\` so drizzle-kit reliably picks it for migrations via direct TCP — regardless of PNPM hoisting. A comment in \`drizzle.config.ts\` explains why.

## Problem found: test regression from barrel import

After adding early \`POSTGRES_URL\` validation to \`packages/db/src/index.ts\`, unit tests in the web app started failing with:

```
Error: POSTGRES_URL is not set
```

**Root cause:**

The test file \`src/lib/search-utils.test.ts\` transitively imported \`@repo/db\` through this chain:

```
test → api-local-json → create-api → api-projects → @repo/db
```

\`api-projects.tsx\` had a top-level \`import { db } from "@repo/db"\` for \`findRandomFeaturedProjects\`, which is unrelated to the in-memory JSON querying that the test exercises. Because \`@repo/db\` validates \`POSTGRES_URL\` at module load time, importing it in a test environment (where no DB is needed) threw immediately.

**Fix:**

Extract \`findRandomFeaturedProjects\` into a standalone \`apps/web/src/server/featured-projects.ts\` module with its own static \`@repo/db\` imports. This file sits outside the \`create-api → api-projects\` chain, so tests that don't need DB access are never affected. The two callers (\`route.ts\` and \`home-featured-projects.tsx\`) import it directly, passing \`getProjectBySlug\` as a parameter.

## How to test

Ensure the migration script works locally:

```
pnpm -F db migrate
```

Ensure unit tests pass without a database:

```
pnpm -F web test src/lib/search-utils.test.ts --run
```