### PR TITLE
Move featured projects to DB-only query

### DIFF
--- a/apps/web/src/app/api/featured-projects/route.ts
+++ b/apps/web/src/app/api/featured-projects/route.ts
@@ -1,4 +1,3 @@
-import { api } from "@/server/api-remote-json";
 import { findRandomFeaturedProjects } from "@/server/featured-projects";
 
 export async function GET(request: Request) {
@@ -7,10 +6,7 @@ export async function GET(request: Request) {
   const limitParam = searchParams.get("limit");
   const skip = skipParam ? parseInt(skipParam) : 0;
   const limit = limitParam ? parseInt(limitParam) : 0;
-  const output = await findRandomFeaturedProjects(
-    api.projects.getProjectBySlug,
-    { skip, limit },
-  );
+  const output = await findRandomFeaturedProjects({ skip, limit });
 
   return new Response(JSON.stringify(output), {
     status: 200,

--- a/apps/web/src/app/api/featured-projects/route.ts
+++ b/apps/web/src/app/api/featured-projects/route.ts
@@ -1,11 +1,23 @@
+import { z } from "zod";
+
 import { findRandomFeaturedProjects } from "@/server/featured-projects";
+
+const featuredProjectsQuerySchema = z.object({
+  skip: z.coerce.number().int().min(0),
+  limit: z.coerce.number().int().min(1).max(100),
+});
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const skipParam = searchParams.get("skip");
-  const limitParam = searchParams.get("limit");
-  const skip = skipParam ? parseInt(skipParam) : 0;
-  const limit = limitParam ? parseInt(limitParam) : 0;
+  const parsed = parseFeaturedProjectsQuery(searchParams);
+  if (!parsed.success) {
+    return new Response(JSON.stringify({ error: "Invalid query parameters" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const { skip, limit } = parsed.data;
   const output = await findRandomFeaturedProjects({ skip, limit });
 
   return new Response(JSON.stringify(output), {
@@ -13,5 +25,12 @@ export async function GET(request: Request) {
     headers: {
       "content-type": "application/json",
     },
+  });
+}
+
+function parseFeaturedProjectsQuery(searchParams: URLSearchParams) {
+  return featuredProjectsQuerySchema.safeParse({
+    skip: searchParams.get("skip") || 0,
+    limit: searchParams.get("limit") || 5,
   });
 }

--- a/apps/web/src/components/home/featured-project-list.tsx
+++ b/apps/web/src/components/home/featured-project-list.tsx
@@ -5,13 +5,14 @@ import type { SortOptionKey } from "@/components/project-list/sort-order-options
 import { ProjectTag } from "@/components/tags/project-tag";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import type { FeaturedProject as FeaturedProjectData } from "@/server/featured-projects";
 
 import { linkVariants } from "../ui/link";
 
 export function FeaturedProjectList({
   projects,
 }: {
-  projects: BestOfJS.Project[];
+  projects: FeaturedProjectData[];
 }) {
   return (
     <ProjectListContainer>
@@ -26,7 +27,7 @@ function FeaturedProject({
   project,
   metrics,
 }: {
-  project: BestOfJS.Project;
+  project: FeaturedProjectData;
   metrics: SortOptionKey;
 }) {
   const delta = getDeltaByDay(metrics)(project);

--- a/apps/web/src/components/home/home-featured-projects.client.tsx
+++ b/apps/web/src/components/home/home-featured-projects.client.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/home/featured-project-list";
 import { Button } from "@/components/ui/button";
 import { CardHeader } from "@/components/ui/card";
+import type { FeaturedProject } from "@/server/featured-projects";
 
 const forceLoadingState = false; // for debugging
 
@@ -121,7 +122,7 @@ function DynamicFeaturedProjectList({
     return <ProjectListSkeleton numberOfItems={numberOfProjectPerPage} />;
   }
 
-  return <FeaturedProjectList projects={projects as BestOfJS.Project[]} />;
+  return <FeaturedProjectList projects={projects as FeaturedProject[]} />;
 }
 
 async function fetchRandomProjects(
@@ -133,5 +134,5 @@ async function fetchRandomProjects(
   params.set("limit", numberOfProjectPerPage.toString());
   const url = "/api/featured-projects?" + params.toString();
   const data = await fetch(url).then((res) => res.json());
-  return data.projects as BestOfJS.Project[];
+  return data.projects as FeaturedProject[];
 }

--- a/apps/web/src/components/home/home-featured-projects.tsx
+++ b/apps/web/src/components/home/home-featured-projects.tsx
@@ -4,7 +4,6 @@ import { FeaturedProjectList } from "@/components/home/featured-project-list";
 import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import { api } from "@/server/api";
 import { findRandomFeaturedProjects } from "@/server/featured-projects";
 
 import { FeaturedProjectsClient } from "./home-featured-projects.client";
@@ -13,9 +12,10 @@ type Props = {
   numberOfProjectPerPage?: number;
 };
 export async function FeaturedProjects({ numberOfProjectPerPage = 5 }: Props) {
-  const { projects, total } = await fetchFeaturedProjects(
-    numberOfProjectPerPage,
-  );
+  const { projects, total } = await findRandomFeaturedProjects({
+    skip: 0,
+    limit: numberOfProjectPerPage,
+  });
   return (
     <Card>
       <FeaturedProjectsClient
@@ -37,12 +37,4 @@ export async function FeaturedProjects({ numberOfProjectPerPage = 5 }: Props) {
       </div>
     </Card>
   );
-}
-
-async function fetchFeaturedProjects(numberOfProjectPerPage: number) {
-  const { projects, total } = await findRandomFeaturedProjects(
-    api.projects.getProjectBySlug,
-    { skip: 0, limit: numberOfProjectPerPage },
-  );
-  return { projects, total };
 }

--- a/apps/web/src/server/featured-projects.ts
+++ b/apps/web/src/server/featured-projects.ts
@@ -1,22 +1,17 @@
-import { db, schema } from "@repo/db";
-import { desc } from "@repo/db/drizzle";
+import { db } from "@repo/db";
+import { findFeaturedProjects } from "@repo/db/projects";
 
-type GetProjectBySlug = (
-  slug: string,
-) => Promise<{ project: BestOfJS.Project | undefined }>;
+export type { FeaturedProject } from "@repo/db/projects";
 
-export async function findRandomFeaturedProjects(
-  getProjectBySlug: GetProjectBySlug,
-  { skip = 0, limit = 5 }: { skip?: number; limit?: number } = {},
-) {
-  const record = await db.query.dailyFeaturedProjects.findFirst({
-    orderBy: desc(schema.dailyFeaturedProjects.createdAt),
-  });
-  const allSlugs = record?.projectSlugs ?? [];
-  const slugs = allSlugs.slice(skip, skip + limit);
-  const results = await Promise.all(slugs.map(getProjectBySlug));
-  const projects = results
-    .map((r) => r.project)
-    .filter((p): p is BestOfJS.Project => p !== undefined);
-  return { projects, total: allSlugs.length };
+// TODO: Revisit this wrapper once listings are fully DB-driven
+// (see docs/prd/replace-static-api-with-db.md): keep a consistent server
+// boundary across listing queries or inline direct DB calls.
+export async function findRandomFeaturedProjects({
+  skip = 0,
+  limit = 5,
+}: {
+  skip?: number;
+  limit?: number;
+} = {}) {
+  return findFeaturedProjects(db, { skip, limit });
 }

--- a/docs/prd/replace-static-api-with-db.md
+++ b/docs/prd/replace-static-api-with-db.md
@@ -134,3 +134,5 @@ A good test verifies observable behavior (query results, score values for known 
 Both new tables are small (~200KB + ~150KB for ~3k projects). Sub-millisecond queries even without indexes, but indexes are defined on all sort columns for future scale.
 
 Migration is incremental: the daily task and new tables can be deployed and validated before any web app page is switched over. Parity validation: deploy DB-backed branch to a Vercel preview URL and compare against production — total project counts within ~5%, top-20 overlap >80% per sort option, spot-check popular tags (react, vue, typescript).
+
+Featured projects currently use a small web-server wrapper around the DB query (`apps/web/src/server/featured-projects.ts`); revisit this once listing/search queries are fully migrated so query access follows one consistent pattern.

--- a/packages/db/src/projects/find-featured.ts
+++ b/packages/db/src/projects/find-featured.ts
@@ -1,0 +1,80 @@
+import { asc, desc, inArray } from "drizzle-orm";
+
+import type { DB } from "../index";
+import * as schema from "../schema";
+import { computeTrends } from "../snapshots/compute-trends";
+import type { Snapshot } from "../snapshots/types";
+import { snapshotsSchema } from "./get";
+
+export type FeaturedProject = {
+  slug: string;
+  name: string;
+  logo: string | null;
+  owner_id: number;
+  trends: {
+    daily?: number;
+    weekly?: number;
+    monthly?: number;
+    quarterly?: number;
+    yearly?: number;
+  };
+  tags: Array<{ code: string; name: string; description: string | null }>;
+};
+
+export async function findFeaturedProjects(
+  db: DB,
+  { skip = 0, limit = 5 }: { skip?: number; limit?: number } = {},
+): Promise<{ projects: FeaturedProject[]; total: number }> {
+  const record = await db.query.dailyFeaturedProjects.findFirst({
+    orderBy: desc(schema.dailyFeaturedProjects.createdAt),
+  });
+  const allSlugs = record?.projectSlugs ?? [];
+  const slugs = allSlugs.slice(skip, skip + limit);
+
+  if (!slugs.length) return { projects: [], total: allSlugs.length };
+
+  const rawProjects = await db.query.projects.findMany({
+    where: inArray(schema.projects.slug, slugs),
+    with: {
+      repo: {
+        with: {
+          snapshots: {
+            orderBy: asc(schema.snapshots.year),
+            columns: { year: true, months: true },
+          },
+        },
+      },
+      projectsToTags: { with: { tag: true } },
+    },
+  });
+
+  // Preserve the random order from the slug list
+  const bySlug = new Map(rawProjects.map((p) => [p.slug, p]));
+  const projects = slugs
+    .map((slug) => bySlug.get(slug))
+    .filter((p): p is NonNullable<typeof p> => p != null)
+    .map((p) => {
+      const yearRows = snapshotsSchema.parse(p.repo?.snapshots ?? []);
+      const snapshots = yearRows.flatMap(({ year, months }) =>
+        months.flatMap(({ month, snapshots }) =>
+          snapshots.map(
+            ({ day, stars }): Snapshot => ({ year, month, day, stars }),
+          ),
+        ),
+      );
+      return {
+        slug: p.slug,
+        name: p.name,
+        logo: p.logo,
+        owner_id: p.repo?.owner_id ?? 0,
+        trends: computeTrends(snapshots),
+        tags: p.projectsToTags.map((pt) => ({
+          code: pt.tag.code,
+          name: pt.tag.name,
+          description: pt.tag.description,
+        })),
+      };
+    });
+
+  return { projects, total: allSlugs.length };
+}

--- a/packages/db/src/projects/find-featured.ts
+++ b/packages/db/src/projects/find-featured.ts
@@ -20,7 +20,7 @@ export type FeaturedProject = {
   };
   tags: Array<{ code: string; name: string; description: string | null }>;
 };
-
+[];
 export async function findFeaturedProjects(
   db: DB,
   { skip = 0, limit = 5 }: { skip?: number; limit?: number } = {},
@@ -55,7 +55,7 @@ export async function findFeaturedProjects(
     .filter((p): p is NonNullable<typeof p> => p != null)
     .map((p) => {
       const yearRows = snapshotsSchema.parse(p.repo?.snapshots ?? []);
-      const snapshots = yearRows.flatMap(({ year, months }) =>
+      const dailySnapshots = yearRows.flatMap(({ year, months }) =>
         months.flatMap(({ month, snapshots }) =>
           snapshots.map(
             ({ day, stars }): Snapshot => ({ year, month, day, stars }),
@@ -66,8 +66,8 @@ export async function findFeaturedProjects(
         slug: p.slug,
         name: p.name,
         logo: p.logo,
-        owner_id: p.repo?.owner_id ?? 0,
-        trends: computeTrends(snapshots),
+        owner_id: p.repo.owner_id,
+        trends: computeTrends(dailySnapshots),
         tags: p.projectsToTags.map((pt) => ({
           code: pt.tag.code,
           name: pt.tag.name,

--- a/packages/db/src/projects/index.ts
+++ b/packages/db/src/projects/index.ts
@@ -1,5 +1,6 @@
 export * from "./create";
 export * from "./find";
+export * from "./find-featured";
 export * from "./get";
 export * from "./packages";
 export * from "./project-helpers";


### PR DESCRIPTION
## Goal

As part of https://github.com/bestofjs/bestofjs/issues/413 and following a PR bot finding, move the \"Featured projects\" feature to a DB-only query — it no longer relies on the static JSON API.

## Problem

The previous implementation called `getProjectBySlug` once per featured slug inside `Promise.all(slugs.map(getProjectBySlug))`. Each call to `getProjectBySlug` internally called `getData()`, which rebuilt the full tag map and `projectsBySlug` lookup from the static JSON file on every invocation. With ~5 slugs per page load this was an N+1 `getData()` pattern.

## Solution

Created `findFeaturedProjects(db, { skip, limit })` in `packages/db/src/projects/find-featured.ts`:

- Reads the latest `dailyFeaturedProjects` record (the pre-shuffled slug list)
- Slices the requested page of slugs
- Fetches all projects in a **single** `db.query.projects.findMany` with `inArray(schema.projects.slug, slugs)`, joining repos, snapshots, and tags in one round-trip
- Reorders results to preserve the random shuffle from the slug list
- Computes star trends via the existing `computeTrends()` helper (same as other DB queries)

`apps/web/src/server/featured-projects.ts` is now a 4-line wrapper around this DB function. The `getProjectBySlug` injection parameter is gone entirely.


## How to test

1. Run `pnpm -F web dev` and open the homepage
2. Verify the \"Featured\" section renders project cards (logo, name, daily star delta, tag chip)
3. Click the Next/Previous buttons — pagination should load new random projects
4. Run `pnpm -F web typecheck` — should be clean