### PR TITLE
Improve UI project table

### DIFF
--- a/apps/web/src/components/core/project.tsx
+++ b/apps/web/src/components/core/project.tsx
@@ -53,13 +53,13 @@ export const StarDeltaAverage = ({ value }: Props) => {
     return <div className="star-delta text-muted-foreground text-sm">N/A</div>;
 
   return (
-    <div className="flex items-center">
+    <div className="inline-flex items-center whitespace-nowrap">
       <div>
         <span>{sign}</span>
         <span>{integerPart}</span>
         <span>.{decimalPart}</span>
       </div>
-      <div className="inline-flex items-center">
+      <div className="inline-flex items-center whitespace-nowrap">
         <StarIcon />
         <span> /day</span>
       </div>

--- a/apps/web/src/components/core/project.tsx
+++ b/apps/web/src/components/core/project.tsx
@@ -47,13 +47,13 @@ function StarDeltaNormal({ value }: Props) {
   );
 }
 
-/** Display: integer when |value| >= 100; one decimal when |value| < 100. */
+/** Integer when one-decimal-rounded magnitude is >= 100; else one decimal. */
 function formatAverageStarDeltaMagnitude(value: number): string {
-  const abs = Math.abs(value);
-  if (abs >= 100) {
-    return String(Math.round(abs));
+  const roundedOneDecimal = Math.round(Math.abs(value) * 10) / 10;
+  if (roundedOneDecimal >= 100) {
+    return String(Math.round(roundedOneDecimal));
   }
-  return (Math.round(abs * 10) / 10).toFixed(1);
+  return roundedOneDecimal.toFixed(1);
 }
 
 export function StarDeltaAverage({ value }: Props) {

--- a/apps/web/src/components/core/project.tsx
+++ b/apps/web/src/components/core/project.tsx
@@ -6,26 +6,31 @@ type Props = {
   value: number;
 };
 
-export const DownloadCount = ({ value }: Props) => {
+export function DownloadCount({ value }: Props) {
   if (value === undefined) {
     return <div className="star-delta text-sm">N/A</div>;
   }
 
   return <span>{formatNumber(value, "compact")}</span>;
-};
+}
 
-const getSign = (value: number) => {
+function getSign(value: number) {
   if (value === 0) return "";
   return value > 0 ? "+" : "-";
-};
+}
 
-export const StarDelta = ({
+export function StarDelta({
   average,
   ...props
-}: Props & { average?: boolean }) =>
-  average ? <StarDeltaAverage {...props} /> : <StarDeltaNormal {...props} />;
+}: Props & { average?: boolean }) {
+  return average ? (
+    <StarDeltaAverage {...props} />
+  ) : (
+    <StarDeltaNormal {...props} />
+  );
+}
 
-const StarDeltaNormal = ({ value }: Props) => {
+function StarDeltaNormal({ value }: Props) {
   const sign = getSign(value);
   return (
     <div className="inline-flex items-center">
@@ -40,24 +45,29 @@ const StarDeltaNormal = ({ value }: Props) => {
       )}
     </div>
   );
-};
+}
 
-export const StarDeltaAverage = ({ value }: Props) => {
-  const integerPart = Math.abs(Math.trunc(value));
-  const decimalPart = (Math.abs(value - integerPart) * 10)
-    .toFixed()
-    .slice(0, 1);
-  const sign = getSign(value);
+/** Display: integer when |value| >= 100; one decimal when |value| < 100. */
+function formatAverageStarDeltaMagnitude(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 100) {
+    return String(Math.round(abs));
+  }
+  return (Math.round(abs * 10) / 10).toFixed(1);
+}
 
+export function StarDeltaAverage({ value }: Props) {
   if (value === undefined)
     return <div className="star-delta text-muted-foreground text-sm">N/A</div>;
+
+  const sign = getSign(value);
+  const magnitude = formatAverageStarDeltaMagnitude(value);
 
   return (
     <div className="inline-flex items-center whitespace-nowrap">
       <div>
         <span>{sign}</span>
-        <span>{integerPart}</span>
-        <span>.{decimalPart}</span>
+        <span>{magnitude}</span>
       </div>
       <div className="inline-flex items-center whitespace-nowrap">
         <StarIcon />
@@ -65,20 +75,19 @@ export const StarDeltaAverage = ({ value }: Props) => {
       </div>
     </div>
   );
-};
+}
 
-export const StarTotal = ({ value }: Props) => {
+export function StarTotal({ value }: Props) {
   return (
     <div className="inline-flex items-center">
       <span>{formatNumber(value, "compact")}</span>
       <StarIcon />
     </div>
   );
-};
+}
 
-export const getDeltaByDay =
-  (period: string) =>
-  ({ trends }: { trends: BestOfJS.Project["trends"] }) => {
+export function getDeltaByDay(period: string) {
+  function deltaForProject({ trends }: { trends: BestOfJS.Project["trends"] }) {
     const periods = {
       daily: 1,
       weekly: 7,
@@ -90,7 +99,10 @@ export const getDeltaByDay =
     const delta = trends[period as keyof BestOfJS.Project["trends"]];
     const numberOfDays = periods[period as keyof BestOfJS.Project["trends"]];
     return average(delta, numberOfDays);
-  };
+  }
+
+  return deltaForProject;
+}
 
 function average(delta: number | undefined, numberOfDays: number) {
   if (delta === undefined) return undefined; // handle recently added projects, without `yearly`, `monthly` data available

--- a/apps/web/src/components/project-list/project-table.tsx
+++ b/apps/web/src/components/project-list/project-table.tsx
@@ -145,7 +145,7 @@ const ProjectTableRow = ({
       )}
 
       {metricsCell && (
-        <Cell className="hidden w-[100px] p-4 text-right md:table-cell">
+        <Cell className="hidden w-[128px] p-4 text-right md:table-cell">
           {metricsCell(project)}
         </Cell>
       )}


### PR DESCRIPTION
## Goal

Fix rendering of number of stars by day in projects table

## How to test

- Go to `/projects` with a sort that shows average stars per day (e.g. monthly).
- On a desktop breakpoint, confirm the right-hand metric stays on a single line for long values.


## Screenshots

<img width="1103" height="672" alt="image" src="https://github.com/user-attachments/assets/52ce7611-eeaf-42f7-be33-8a5c44e915d8" />
