### PR TITLE
Make rankings DB driven step 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,4 @@ pnpm biome check --write .   # Auto-fix formatting/lint issues
 - `docs/architecture/overview.md` — full system design
 - `docs/architecture/backend-app.md` — task system and data collection
 - `docs/architecture/web-app.md` — frontend architecture
+- `docs/architecture/scoring.md` — project scoring formulas, calibration decisions, and how to tune them

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -47,3 +47,15 @@ Some flag are available at the global level (for all tasks):
 Additional flags can be available at the task level, the task definition will get extra `flags` and `schema` parameters to handle them.
 
 Check the `--help` command related to each task for more details.
+
+## Manual tests
+
+The `check-trends-queries` task is a manual test for the web listing queries (`findProjectsWithTrends()` in `@repo/db`), to be run against the local or production database. It prints the query results and checks invariants on real data: the relevance floor, the sort order (`NULLS LAST`), and the tag filter.
+
+```sh
+pnpm -F backend check-trends-queries
+bun run apps/backend/src/cli.ts check-trends-queries --sort most-used --tags react,ui
+bun run apps/backend/src/cli.ts check-trends-queries --search jquery --fullCatalog
+```
+
+The task exits with a warning if any invariant is violated.

--- a/apps/backend/src/backup/README.md
+++ b/apps/backend/src/backup/README.md
@@ -16,7 +16,9 @@ pnpm backup
 ## Restore
 
 Drop and recreate the local database, then load a `db-backup` dump into it.
-Targets the local Docker database via `.env.development` so it can never hit a remote DB.
+Targets the local Docker database via `.env.development`, and refuses to run
+against any non-local host (see `LOCAL_HOSTS` in the script), so it can never
+hit a remote DB.
 
 ```sh
 pnpm restore                  # restore the latest backup (prompts for confirmation)

--- a/apps/backend/src/backup/README.md
+++ b/apps/backend/src/backup/README.md
@@ -1,9 +1,30 @@
 # Database backup
 
-Script to be run manually to generate a backup of the Postgres database in the folder `db-backup`, at the root of the monorepo.
+Scripts to be run manually to backup and restore the local Postgres database in the folder `db-backup`, at the root of the monorepo.
 
-Requirement: `pg_dump` (should come with `psql`)
+Requirement: `pg_dump` / `psql` (the PostgreSQL client tools).
+
+## Backup
+
+Generate a new `db-backup/<year>/backup-NNN.sql` dump from the database referenced by `POSTGRES_URL`:
 
 ```sh
-NODE_ENV=production bun run ./apps/backend/src/backup/make-backup.ts
+pnpm backup
+# or: NODE_ENV=production bun run ./apps/backend/src/backup/make-backup.ts
 ```
+
+## Restore
+
+Drop and recreate the local database, then load a `db-backup` dump into it.
+Targets the local Docker database via `.env.development` so it can never hit a remote DB.
+
+```sh
+pnpm restore                  # restore the latest backup (prompts for confirmation)
+pnpm restore 7                # restore backup-007.sql
+pnpm restore backup-003.sql   # restore a specific file
+pnpm restore --list           # list available backups
+pnpm restore --dryRun         # print the commands without executing them
+pnpm restore --yes            # skip the confirmation prompt
+```
+
+The restore recreates the `default` role used by the dump's `OWNER` clauses, drops and recreates the target database, then pipes the SQL file into `psql`.

--- a/apps/backend/src/backup/backup-utils.ts
+++ b/apps/backend/src/backup/backup-utils.ts
@@ -1,0 +1,65 @@
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const BACKUP_FOLDER = "db-backup";
+
+export function getBackupFolderFullPath() {
+  const year = new Date().getFullYear();
+  return path.join(process.cwd(), BACKUP_FOLDER, year.toString());
+}
+
+export function getPreviousBackupFilenames(): string[] {
+  const filepath = getBackupFolderFullPath();
+  if (!existsSync(filepath))
+    throw new Error(`Backup folder not found: ${filepath}`);
+  const fileNames = readdirSync(filepath).filter(
+    (name) => extractBackupNumber(name) !== null,
+  );
+  fileNames.sort();
+  return fileNames;
+}
+
+export function extractBackupNumber(fileName: string): number | null {
+  const match = fileName.match(/backup-(\d+)\.sql/);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+export function getNextBackupNumber(): number {
+  const fileNames = getPreviousBackupFilenames();
+  const lastFileName = fileNames.at(-1);
+  if (!lastFileName) return 1;
+  const lastBackupNumber = extractBackupNumber(lastFileName);
+  if (!lastBackupNumber) throw new Error("Invalid backup filename");
+  return lastBackupNumber + 1;
+}
+
+export function getNextBackupFilename(): string {
+  const nextBackupNumber = getNextBackupNumber();
+  const formattedNumber = nextBackupNumber.toString().padStart(3, "0");
+  return `backup-${formattedNumber}.sql`;
+}
+
+/** Resolve a user-supplied selector (filename, "latest", or a bare number) to a full path. */
+export function resolveBackupPath(selector?: string): string {
+  const folder = getBackupFolderFullPath();
+  const fileNames = getPreviousBackupFilenames();
+
+  if (!selector || selector === "latest") {
+    const latest = fileNames.at(-1);
+    if (!latest) throw new Error(`No backup found in ${folder}`);
+    return path.join(folder, latest);
+  }
+
+  // Allow passing a bare number (e.g. "7" or "007") or a full filename.
+  const asNumber = /^(\d+)$/.test(selector)
+    ? Number.parseInt(selector, 10)
+    : extractBackupNumber(selector);
+  if (asNumber === null)
+    throw new Error(`Invalid backup selector: ${selector}`);
+
+  const formatted = `backup-${asNumber.toString().padStart(3, "0")}.sql`;
+  if (!fileNames.includes(formatted))
+    throw new Error(`Backup not found: ${formatted}`);
+
+  return path.join(folder, formatted);
+}

--- a/apps/backend/src/backup/make-backup.ts
+++ b/apps/backend/src/backup/make-backup.ts
@@ -1,7 +1,8 @@
-import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import consola from "consola";
 import prettyMs from "pretty-ms";
+
+import { getBackupFolderFullPath, getNextBackupFilename } from "./backup-utils";
 
 main();
 
@@ -12,7 +13,7 @@ async function main() {
   const nextBackupFilename = getNextBackupFilename();
   console.log(nextBackupFilename);
 
-  const filepath = path.join(getFolderFullPath(), nextBackupFilename);
+  const filepath = path.join(getBackupFolderFullPath(), nextBackupFilename);
   await launchBackupCommand(url, filepath);
 }
 
@@ -29,40 +30,4 @@ async function launchBackupCommand(dbURL: string, filepath: string) {
   } catch (error) {
     consola.error("Backup failed", error);
   }
-}
-
-function getFolderFullPath() {
-  const year = new Date().getFullYear();
-  return path.join(process.cwd(), "db-backup", year.toString());
-}
-
-function getNextBackupFilename() {
-  const nextBackupNumber = getNextBackupNumber();
-  const formattedNumber = nextBackupNumber.toString().padStart(3, "0");
-  return `backup-${formattedNumber}.sql`;
-}
-
-function getNextBackupNumber() {
-  const fileNames = getPreviousBackupFilenames();
-  const lastFileName = fileNames.at(-1);
-  if (!lastFileName) return 1;
-  const lastBackupNumber = extractBackupNumber(lastFileName);
-  if (!lastBackupNumber) {
-    throw new Error("Invalid backup filename");
-  }
-  return lastBackupNumber + 1;
-}
-
-function getPreviousBackupFilenames() {
-  const filepath = getFolderFullPath();
-  if (!existsSync(filepath))
-    throw new Error(`Backup folder not found: ${filepath}`);
-  const fileNames = readdirSync(filepath);
-  fileNames.sort();
-  return fileNames;
-}
-
-function extractBackupNumber(fileName: string): number | null {
-  const match = fileName.match(/backup-(\d+)\.sql/);
-  return match ? parseInt(match[1], 10) : null;
 }

--- a/apps/backend/src/backup/restore-backup.ts
+++ b/apps/backend/src/backup/restore-backup.ts
@@ -143,16 +143,17 @@ async function nukeDatabase(
   ];
 
   consola.info("Dropping and recreating database...");
-  if (dryRun) {
-    for (const statement of sql) console.log(`  psql -c ${statement}`);
-    return;
-  }
-
   const args = ["-v", "ON_ERROR_STOP=1"];
   for (const statement of sql) {
     args.push("-c", statement);
   }
-  await runPsql([maintenanceUrl, ...args]);
+  const fullArgs = [maintenanceUrl, ...args];
+  if (dryRun) {
+    console.log(`  ${shellCommand("psql", fullArgs)}`);
+    return;
+  }
+
+  await runPsql(fullArgs);
 }
 
 async function restoreDump(
@@ -161,8 +162,9 @@ async function restoreDump(
   dryRun: boolean,
 ) {
   consola.info("Restoring dump...");
+  const args = [targetUrl, "-v", "ON_ERROR_STOP=1"];
   if (dryRun) {
-    console.log(`  psql ${targetUrl} < ${filepath}`);
+    console.log(`  ${shellCommand("psql", args)} < ${shellQuote(filepath)}`);
     return;
   }
   // ON_ERROR_STOP=1 so any real restore error (corrupt dump, failed CREATE, missing
@@ -170,7 +172,7 @@ async function restoreDump(
   // being swallowed and reported as a successful partial restore. The dump's OWNER
   // clauses target the `default` role, which nukeDatabase creates first, and psql
   // NOTICE/WARNING messages never abort regardless of this setting.
-  await runPsql([targetUrl, "-v", "ON_ERROR_STOP=1"], { stdinFile: filepath });
+  await runPsql(args, { stdinFile: filepath });
 }
 
 async function runPsql(
@@ -187,6 +189,16 @@ async function runPsql(
   if (exitCode !== 0) {
     throw new Error(`psql exited with code ${exitCode}`);
   }
+}
+
+/** Shell-quote a single arg so it survives copy/paste into a POSIX shell. */
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/** Render `command` + `args` as a copy-pasteable shell command matching `Bun.spawn`. */
+function shellCommand(command: string, args: string[]): string {
+  return [command, ...args.map(shellQuote)].join(" ");
 }
 
 /** Return a copy of `url` pointing at `dbName` (replaces the path segment). */

--- a/apps/backend/src/backup/restore-backup.ts
+++ b/apps/backend/src/backup/restore-backup.ts
@@ -75,6 +75,8 @@ async function run(flags: RunFlags, selector?: string) {
     return;
   }
 
+  assertLocalDb(url);
+
   const targetDb = flags.dbName;
   const filepath = resolveBackupPath(selector);
   if (!existsSync(filepath))
@@ -192,4 +194,30 @@ function swapDatabase(url: string, dbName: string): string {
   const parsed = new URL(url);
   parsed.pathname = `/${dbName}`;
   return parsed.toString();
+}
+
+/**
+ * Hostnames that can never route to a remote/prod database. restore-backup is a
+ * local-dev-only tool that DROPs its target, so we refuse to run against any
+ * host outside this set — even on `--dryRun`, so a dry run against a stray prod
+ * URL can't be mistaken for safety.
+ */
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "postgres"]);
+
+function assertLocalDb(url: string): void {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    throw new Error(`POSTGRES_URL is not a valid URL: ${url}`);
+  }
+  // `new URL` keeps brackets around IPv6 hostnames.
+  const normalized = hostname.replace(/^\[|\]$/g, "");
+  if (!LOCAL_HOSTS.has(normalized)) {
+    throw new Error(
+      `Refusing to restore: POSTGRES_URL host "${normalized}" is not a known local host. ` +
+        "restore-backup DROPs its target database and is local-dev-only. " +
+        `Point POSTGRES_URL at a local database (one of: ${Array.from(LOCAL_HOSTS).join(", ")}).`,
+    );
+  }
 }

--- a/apps/backend/src/backup/restore-backup.ts
+++ b/apps/backend/src/backup/restore-backup.ts
@@ -163,8 +163,12 @@ async function restoreDump(
     console.log(`  psql ${targetUrl} < ${filepath}`);
     return;
   }
-  // ON_ERROR_STOP=0 so owner/permission warnings from the dump don't abort the load.
-  await runPsql([targetUrl, "-v", "ON_ERROR_STOP=0"], { stdinFile: filepath });
+  // ON_ERROR_STOP=1 so any real restore error (corrupt dump, failed CREATE, missing
+  // extension) aborts psql with a non-zero exit code that runPsql surfaces, instead of
+  // being swallowed and reported as a successful partial restore. The dump's OWNER
+  // clauses target the `default` role, which nukeDatabase creates first, and psql
+  // NOTICE/WARNING messages never abort regardless of this setting.
+  await runPsql([targetUrl, "-v", "ON_ERROR_STOP=1"], { stdinFile: filepath });
 }
 
 async function runPsql(

--- a/apps/backend/src/backup/restore-backup.ts
+++ b/apps/backend/src/backup/restore-backup.ts
@@ -1,0 +1,191 @@
+import { existsSync } from "node:fs";
+import { cli } from "cleye";
+import consola from "consola";
+import prettyMs from "pretty-ms";
+
+import {
+  getBackupFolderFullPath,
+  getPreviousBackupFilenames,
+  resolveBackupPath,
+} from "./backup-utils";
+
+const TARGET_DB_DEFAULT = "bestofjs-dev";
+
+main();
+
+/** Restore a local Postgres database from a `db-backup` SQL dump. */
+async function main() {
+  cli(
+    {
+      name: "restore-backup",
+      help: {
+        description:
+          "Drop and recreate the local database, then restore it from a `db-backup` SQL dump.",
+        usage:
+          "bun run ./apps/backend/src/backup/restore-backup.ts [selector] [flags]",
+        examples: [
+          "restore-backup              # restore the latest backup",
+          "restore-backup 7            # restore backup-007.sql",
+          "restore-backup backup-003.sql",
+          "restore-backup --list       # list available backups",
+          "restore-backup --dryRun     # print commands without executing",
+        ],
+      },
+      parameters: ["[selector]"],
+      flags: {
+        list: {
+          description: "List available backups and exit",
+          type: Boolean,
+        },
+        yes: {
+          description: "Skip the confirmation prompt",
+          type: Boolean,
+          alias: "y",
+        },
+        dryRun: {
+          description: "Print the commands without executing them",
+          type: Boolean,
+        },
+        dbName: {
+          description: "Target database name (defaults to bestofjs-dev)",
+          type: String,
+          default: TARGET_DB_DEFAULT,
+        },
+      },
+    },
+    (argv) => {
+      void run(argv.flags as RunFlags, argv._.selector);
+    },
+  );
+}
+
+type RunFlags = {
+  list: boolean;
+  yes: boolean;
+  dryRun: boolean;
+  dbName: string;
+};
+
+async function run(flags: RunFlags, selector?: string) {
+  const url = process.env.POSTGRES_URL;
+  if (!url) throw new Error("Missing POSTGRES_URL environment variable");
+
+  if (flags.list) {
+    listBackups();
+    return;
+  }
+
+  const targetDb = flags.dbName;
+  const filepath = resolveBackupPath(selector);
+  if (!existsSync(filepath))
+    throw new Error(`Backup file not found: ${filepath}`);
+
+  consola.box("Restore...", filepath);
+  consola.info(`Target database: ${targetDb}`);
+
+  if (!flags.dryRun && !flags.yes) {
+    const confirmed = await consola.prompt(
+      `This will DROP and recreate the local "${targetDb}" database. Continue?`,
+      { type: "confirm", initial: false },
+    );
+    if (!confirmed) {
+      consola.info("Aborted.");
+      return;
+    }
+  }
+
+  const maintenanceUrl = swapDatabase(url, "postgres");
+  const targetUrl = swapDatabase(url, targetDb);
+
+  const start = Date.now();
+  await nukeDatabase(maintenanceUrl, targetDb, flags.dryRun);
+  await restoreDump(targetUrl, filepath, flags.dryRun);
+
+  if (flags.dryRun) {
+    consola.info("Dry run — no changes were made.");
+    return;
+  }
+  consola.success("Restore done", prettyMs(Date.now() - start));
+}
+
+function listBackups() {
+  const folder = getBackupFolderFullPath();
+  const fileNames = getPreviousBackupFilenames();
+  if (fileNames.length === 0) {
+    consola.info(`No backups found in ${folder}`);
+    return;
+  }
+  consola.info(`Available backups in ${folder}:`);
+  for (const name of fileNames) console.log(`  ${name}`);
+}
+
+/** Drop and recreate the target database via a connection to the maintenance DB. */
+async function nukeDatabase(
+  maintenanceUrl: string,
+  dbName: string,
+  dryRun: boolean,
+) {
+  const createRole = [
+    "DO $$",
+    "BEGIN",
+    "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'default') THEN",
+    '    CREATE ROLE "default" LOGIN;',
+    "  END IF;",
+    "END $$;",
+  ].join(" ");
+
+  const sql = [
+    createRole,
+    `DROP DATABASE IF EXISTS "${dbName}";`,
+    `CREATE DATABASE "${dbName}";`,
+  ];
+
+  consola.info("Dropping and recreating database...");
+  if (dryRun) {
+    for (const statement of sql) console.log(`  psql -c ${statement}`);
+    return;
+  }
+
+  const args = ["-v", "ON_ERROR_STOP=1"];
+  for (const statement of sql) {
+    args.push("-c", statement);
+  }
+  await runPsql([maintenanceUrl, ...args]);
+}
+
+async function restoreDump(
+  targetUrl: string,
+  filepath: string,
+  dryRun: boolean,
+) {
+  consola.info("Restoring dump...");
+  if (dryRun) {
+    console.log(`  psql ${targetUrl} < ${filepath}`);
+    return;
+  }
+  // ON_ERROR_STOP=0 so owner/permission warnings from the dump don't abort the load.
+  await runPsql([targetUrl, "-v", "ON_ERROR_STOP=0"], { stdinFile: filepath });
+}
+
+async function runPsql(
+  args: string[],
+  opts?: { stdinFile?: string },
+): Promise<void> {
+  const stdin = opts?.stdinFile ? Bun.file(opts.stdinFile) : undefined;
+  const proc = Bun.spawn(["psql", ...args], {
+    stdin,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(`psql exited with code ${exitCode}`);
+  }
+}
+
+/** Return a copy of `url` pointing at `dbName` (replaces the path segment). */
+function swapDatabase(url: string, dbName: string): string {
+  const parsed = new URL(url);
+  parsed.pathname = `/${dbName}`;
+  return parsed.toString();
+}

--- a/apps/backend/src/backup/restore-backup.ts
+++ b/apps/backend/src/backup/restore-backup.ts
@@ -9,6 +9,7 @@ import {
   resolveBackupPath,
 } from "./backup-utils";
 
+// Matches `POSTGRES_DB` in docker-compose.yaml (the local dev database).
 const TARGET_DB_DEFAULT = "bestofjs-dev";
 
 main();
@@ -208,21 +209,9 @@ function swapDatabase(url: string, dbName: string): string {
   return parsed.toString();
 }
 
-/**
- * Hostnames that can never route to a remote/prod database. restore-backup is a
- * local-dev-only tool that DROPs its target, so we refuse to run against any
- * host outside this set — even on `--dryRun`, so a dry run against a stray prod
- * URL can't be mistaken for safety.
- */
-const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "postgres"]);
-
 function assertLocalDb(url: string): void {
-  let hostname: string;
-  try {
-    hostname = new URL(url).hostname;
-  } catch {
-    throw new Error(`POSTGRES_URL is not a valid URL: ${url}`);
-  }
+  const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "postgres"]);
+  const hostname = parseHostname(url);
   // `new URL` keeps brackets around IPv6 hostnames.
   const normalized = hostname.replace(/^\[|\]$/g, "");
   if (!LOCAL_HOSTS.has(normalized)) {
@@ -231,5 +220,14 @@ function assertLocalDb(url: string): void {
         "restore-backup DROPs its target database and is local-dev-only. " +
         `Point POSTGRES_URL at a local database (one of: ${Array.from(LOCAL_HOSTS).join(", ")}).`,
     );
+  }
+}
+
+/** Parse the hostname out of a connection URL, throwing a clear error if invalid. */
+function parseHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    throw new Error(`POSTGRES_URL is not a valid URL: ${url}`);
   }
 }

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -6,6 +6,7 @@ import { createTaskRunner } from "./task-runner";
 import type { Task } from "./task-types";
 import { buildMonthlyRankingsTask } from "./tasks/build-monthly-rankings.task";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
+import { checkTrendsQueriesTask } from "./tasks/check-trends-queries.task";
 import { cleanupRepoTrendsTask } from "./tasks/cleanup-repo-trends.task";
 import {
   helloWorldHallOfFameTask,
@@ -42,6 +43,7 @@ const commands = [
   cleanupRepoTrendsTask,
   updateRepoTrendsTask,
   updateProjectTrendsTask,
+  checkTrendsQueriesTask,
   buildMonthlyRankingsTask,
   buildRisingStarsTask,
   cleanupRisingStars,

--- a/apps/backend/src/shared/utils.ts
+++ b/apps/backend/src/shared/utils.ts
@@ -2,3 +2,12 @@ export function truncate(input: string, maxLength = 50) {
   const isTruncated = input.length > maxLength;
   return isTruncated ? `${input.slice(0, maxLength)}...` : input;
 }
+
+const compactNumberFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+export function formatCompactNumber(value: number | null): string | null {
+  return value === null ? null : compactNumberFormatter.format(value);
+}

--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -225,8 +225,7 @@ const COLUMNS = {
     formatCompactNumber(p.trends?.monthly ?? null),
   yearly: (p: ProjectWithTrends) =>
     formatCompactNumber(p.trends?.yearly ?? null),
-  downloads: (p: ProjectWithTrends) =>
-    formatCompactNumber(p.monthlyDownloads ?? 0),
+  downloads: (p: ProjectWithTrends) => formatCompactNumber(p.monthlyDownloads),
   relevance: (p: ProjectWithTrends) => roundScore(p.relevanceScore),
   popularity: (p: ProjectWithTrends) => roundScore(p.popularityScore),
   activity: (p: ProjectWithTrends) => roundScore(p.activityScore),

--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -1,0 +1,270 @@
+import { z } from "zod";
+
+import {
+  findProjectsWithTrends,
+  type ProjectWithTrends,
+} from "@repo/db/projects";
+import {
+  type TrendsSortKey,
+  trendsSortKeySchema,
+} from "@repo/db/shared-schemas";
+
+import { formatCompactNumber } from "@/shared/utils";
+import { createTask } from "@/task-runner";
+
+/**
+ * Manual test for the web listing queries, to be run by devs against the
+ * local or production database. Prints the results of
+ * `findProjectsWithTrends()` for the given flags and checks invariants that
+ * fixtures-free testing can verify on real data:
+ * - relevance floor: no project with `relevance_score < 0` unless `--fullCatalog`
+ * - sort order: values non-increasing, NULLs (missing `repo_trends` row) last
+ * - tag filter: every result has ALL the requested tags
+ * - the full catalog is never smaller than the floored listing
+ */
+export const checkTrendsQueriesTask = createTask({
+  name: "check-trends-queries",
+  description:
+    "Manual test for `findProjectsWithTrends()`: print a web listing query result and check its invariants",
+  flags: {
+    sort: {
+      type: String,
+      description:
+        "Sort option: trending, hot-today, most-stars, most-active, most-used, newest",
+      default: "trending",
+    },
+    tags: {
+      type: String,
+      description: "Comma-separated tag codes; projects must have ALL of them",
+    },
+    search: {
+      type: String,
+      description:
+        "Text search on project name/description and repo owner/name",
+    },
+    fullCatalog: {
+      type: Boolean,
+      description:
+        "Disable the relevance-score floor, querying the full catalog (`/search` mode)",
+      default: false,
+    },
+    page: {
+      type: Number,
+      description: "Page number",
+      default: 1,
+    },
+    columns: {
+      type: String,
+      description:
+        "Comma-separated columns to show, or 'all'. Default: rank,slug,stars,downloads,relevance",
+    },
+  },
+  schema: z.object({
+    sort: trendsSortKeySchema.optional().default("trending"),
+    tags: z.string().optional(),
+    search: z.string().optional(),
+    fullCatalog: z.boolean().optional().default(false),
+    page: z.number().optional().default(1),
+    limit: z.number().optional().default(0), // shared flag; 0 means "not provided"
+    columns: z.string().optional(),
+  }),
+  run: async ({ db, logger }, flags) => {
+    const { sort, search, fullCatalog, page } = flags;
+    const limit = flags.limit || 25;
+    const tagCodes = flags.tags
+      ?.split(",")
+      .map((code) => code.trim())
+      .filter(Boolean);
+
+    const options = {
+      db,
+      sort,
+      query: search,
+      tagCodes,
+      page,
+      limit,
+    };
+    const [floored, full] = await Promise.all([
+      findProjectsWithTrends({ ...options, relevanceFloor: true }),
+      findProjectsWithTrends({ ...options, relevanceFloor: false }),
+    ]);
+    const { projects, total } = fullCatalog ? full : floored;
+
+    const requestedColumns = resolveColumns(flags.columns);
+    if (requestedColumns.unknown.length > 0) {
+      logger.warn(
+        `Unknown column(s): ${requestedColumns.unknown.join(", ")}. Valid: ${Object.keys(COLUMNS).join(", ")}`,
+      );
+    }
+
+    console.table(
+      projects.map((project, index) => {
+        const ctx: RowContext = { index, page, limit };
+        const row: Record<string, unknown> = {};
+        for (const col of requestedColumns.columns) {
+          row[col] = COLUMNS[col](project, ctx);
+        }
+        return row;
+      }),
+    );
+    logger.info(
+      `${projects.length} projects shown (page ${page}), ${total} matching in total`,
+    );
+    logger.info(
+      `The relevance floor hides ${full.total - floored.total} of the ${full.total} matching projects`,
+    );
+
+    const violations = [
+      ...checkRelevanceFloor(projects, fullCatalog),
+      ...checkSortOrder(projects, sort),
+      ...checkTagFilter(projects, tagCodes),
+      ...(full.total >= floored.total
+        ? []
+        : [
+            `Full catalog total (${full.total}) is smaller than the floored total (${floored.total})`,
+          ]),
+    ];
+
+    for (const violation of violations) {
+      logger.error("Invariant violated:", violation);
+    }
+    if (violations.length === 0) {
+      logger.success("All invariants hold");
+    }
+
+    return {
+      data: null,
+      meta: { total, shown: projects.length, error: violations.length },
+    };
+  },
+});
+
+function checkRelevanceFloor(
+  projects: ProjectWithTrends[],
+  fullCatalog: boolean,
+) {
+  if (fullCatalog) return [];
+  return projects
+    .filter((project) => project.relevanceScore < 0)
+    .map(
+      (project) =>
+        `"${project.slug}" has a negative relevance score (${project.relevanceScore}) but the floor is enabled`,
+    );
+}
+
+function checkSortOrder(projects: ProjectWithTrends[], sort: TrendsSortKey) {
+  const violations: string[] = [];
+  let previous: number | undefined;
+  let seenNull = false;
+  for (const project of projects) {
+    const value = getSortValue(project, sort);
+    if (value === null) {
+      seenNull = true;
+      continue;
+    }
+    if (seenNull) {
+      violations.push(
+        `"${project.slug}" has a "${sort}" value but is ranked after projects without one (NULLS LAST violated)`,
+      );
+      continue;
+    }
+    if (previous !== undefined && value > previous) {
+      violations.push(
+        `"${project.slug}" (${value}) is ranked after a project with a lower "${sort}" value (${previous})`,
+      );
+    }
+    previous = value;
+  }
+  return violations;
+}
+
+function getSortValue(project: ProjectWithTrends, sort: TrendsSortKey) {
+  switch (sort) {
+    case "trending":
+      return project.popularityScore;
+    case "hot-today":
+      return project.trends?.daily ?? null;
+    case "most-stars":
+      return project.stars;
+    case "most-active":
+      return project.activityScore;
+    case "most-used":
+      return project.monthlyDownloads;
+    case "newest":
+      return project.createdAt.getTime();
+  }
+}
+
+function checkTagFilter(projects: ProjectWithTrends[], tagCodes?: string[]) {
+  if (!tagCodes || tagCodes.length === 0) return [];
+  return projects
+    .filter(
+      (project) => !tagCodes.every((tagCode) => project.tags.includes(tagCode)),
+    )
+    .map(
+      (project) =>
+        `"${project.slug}" is missing one of the requested tags (found: ${project.tags.join(", ")})`,
+    );
+}
+
+function roundScore(score: number | null) {
+  return score === null ? null : Math.round(score * 10) / 10;
+}
+
+type RowContext = { index: number; page: number; limit: number };
+
+const COLUMNS = {
+  rank: (_p: ProjectWithTrends, { index, page, limit }: RowContext) =>
+    (page - 1) * limit + index + 1,
+  slug: (p: ProjectWithTrends) => p.slug,
+  status: (p: ProjectWithTrends) => p.status,
+  stars: (p: ProjectWithTrends) => formatCompactNumber(p.stars),
+  daily: (p: ProjectWithTrends) => p.trends?.daily ?? null,
+  weekly: (p: ProjectWithTrends) => p.trends?.weekly ?? null,
+  monthly: (p: ProjectWithTrends) =>
+    formatCompactNumber(p.trends?.monthly ?? null),
+  yearly: (p: ProjectWithTrends) =>
+    formatCompactNumber(p.trends?.yearly ?? null),
+  downloads: (p: ProjectWithTrends) =>
+    formatCompactNumber(p.monthlyDownloads ?? 0),
+  relevance: (p: ProjectWithTrends) => roundScore(p.relevanceScore),
+  popularity: (p: ProjectWithTrends) => roundScore(p.popularityScore),
+  activity: (p: ProjectWithTrends) => roundScore(p.activityScore),
+  usage: (p: ProjectWithTrends) => roundScore(p.usageScore),
+  tags: (p: ProjectWithTrends) => p.tags.join(", "),
+} as const satisfies Record<
+  string,
+  (p: ProjectWithTrends, ctx: RowContext) => unknown
+>;
+
+type ColumnKey = keyof typeof COLUMNS;
+
+const DEFAULT_COLUMNS: ColumnKey[] = [
+  "rank",
+  "slug",
+  "stars",
+  "downloads",
+  "relevance",
+];
+
+function resolveColumns(raw: string | undefined): {
+  columns: ColumnKey[];
+  unknown: string[];
+} {
+  if (!raw) return { columns: DEFAULT_COLUMNS, unknown: [] };
+  if (raw === "all") {
+    return { columns: Object.keys(COLUMNS) as ColumnKey[], unknown: [] };
+  }
+  const requested = raw
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+  const known = Object.keys(COLUMNS);
+  const columns: ColumnKey[] = [];
+  const unknown: string[] = [];
+  for (const c of requested) {
+    if (known.includes(c)) columns.push(c as ColumnKey);
+    else unknown.push(c);
+  }
+  return { columns, unknown };
+}

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -1,0 +1,98 @@
+# Project scoring
+
+How Best of JS scores projects for the DB-backed listing and search pages, and why the formulas are what they are. This is the source of truth for scoring decisions; the [PRD](../prd/replace-static-api-with-db.md) documents the original design but is a point-in-time document.
+
+## Overview
+
+Two cache tables store pre-computed scores, refreshed daily by the `daily-update-trends` backend pipeline (cleanup → `update-repo-trends` → `update-project-trends`):
+
+- **`repo_trends`** (one row per repo): raw star deltas (`daily`, `weekly`, `monthly`, `quarterly`, `yearly`) plus `popularity_score` and `activity_score`
+- **`project_trends`** (one row per project, including deprecated ones): primary package, `monthly_downloads`, `usage_score` and `relevance_score`
+
+The three dimension scores (popularity, activity, usage) serve as **sort keys**. The composite `relevance_score` is only a **quality floor** (`WHERE relevance_score >= 0`), never an `ORDER BY`.
+
+The pure functions live in `packages/db/src/repo-trends/scoring.ts` and `packages/db/src/project-trends/scoring.ts`, with unit tests pinning the anchors. Scores are stored, not computed at query time: after changing a formula, re-run the pipeline to see any effect.
+
+## `popularity_score` — star momentum
+
+```
+raw   = yearly + monthly * 6
+score = sign(raw) * log10(1 + |raw| / 10) * 30
+```
+
+Range ~ −100 to +100 (raw +1000/year ≈ 60, +10k/year ≈ 90). Sort key for **Trending**.
+
+**Why daily and weekly are excluded:** GitHub stars have mysterious one-day spikes and drops — spam-account purges, viral bursts. The original formula (`yearly + monthly*6 + daily*180`) let a single day outweigh a year: TanStack Query, at +4.1K stars/year, scored **−46.8** because of one −30 purge day (`−30 × 180 = −5400` vs `4100 + 984` of genuine growth). Monthly and yearly windows dilute this noise. The daily signal keeps its own dedicated sort ("Hot today").
+
+**Young-repo fallback:** repos tracked for less than a month have no monthly delta yet. The monthly momentum is then extrapolated from the freshest window available — `weekly*4`, then `daily*30` — so a hot new project still surfaces in "Trending" during its first weeks. Once a real monthly delta exists, daily/weekly are ignored entirely.
+
+## `activity_score` — maintenance
+
+```
+decay = max(0, 100 - log2(days_since_last_commit + 1) * 10)
+bonus = min(10, log2(contributors) * 3)   when contributors > 1
+score = decay + bonus
+```
+
+Range 0–110. Sort key for **Most active**. Anchors: commit yesterday ≈ 90–100, 1 week ≈ 70, 1 month ≈ 50, 1 year ≈ 15, ~3 years → 0. No commit date → 0 (fully inactive, the "frozen" UI label). The small contributor bonus rewards bus-factor without letting community size dominate recency.
+
+## `usage_score` — NPM adoption
+
+```
+score = max(0, min(100, (log10(monthly_downloads) - 2) * slope))
+slope = 100 / (log10(2_000_000_000) - 2)   ≈ 13.7 per decade
+```
+
+Calibrated so **100 requires 2 billion downloads/month** — a ceiling only the most-downloaded npm packages approach. Anchors:
+
+| Monthly downloads | Score |
+|---|---|
+| 100 | 0 |
+| 10k | ~27 |
+| 1M | ~55 |
+| 10M | ~68 |
+| 100M | ~82 |
+| 1B | ~96 |
+| 2B | 100 |
+
+The original slope (100 at 10M/month) saturated hundreds of popular packages at 100.
+
+**Not a sort key:** the **Most used** sort orders by raw `monthly_downloads`. Any log-scale score buckets projects into ties (the listing then degrades to alphabetical order); raw counts give an exact order. The score only feeds the relevance blend, where clamping is harmless.
+
+## `relevance_score` — the quality floor
+
+```
+with package:    popularity * 0.50 + activity * 0.25 + usage * 0.25
+without package: popularity * 0.65 + activity * 0.35
+deprecated:      minus 17
+```
+
+Used **only** as `WHERE relevance_score >= 0` in listings — never for ordering. The `/search` route drops the filter so the full catalog (including deprecated, low-signal projects) stays findable.
+
+**Why the malus is −17:** deprecated repos lose their `repo_trends` row daily (star tracking stops, a cost saving), so their popularity and activity are 0 and only usage can keep them above the floor: `usage * 0.25 − 17 ≥ 0` requires usage ≈ 68, i.e. **~10M downloads/month**. That keeps jquery-class legacy packages visible in listings while hiding deprecated projects with no meaningful adoption. (−17 preserves the ~10M threshold the original −20 malus had under the old usage slope.)
+
+## Interplay with queries
+
+Because deprecated repos have no `repo_trends` row, the listing query (`findProjectsWithTrends()` in `packages/db`) uses `INNER JOIN project_trends` + `LEFT JOIN repo_trends`, sorts with `NULLS LAST` (trend-less projects sink instead of floating to the top of `DESC` sorts), and falls back to `COALESCE(repo_trends.stars, repos.stars)` for the star count.
+
+| UI label | ORDER BY |
+|---|---|
+| Trending | `repo_trends.popularity_score` |
+| Hot today | `repo_trends.daily` |
+| Most stars | `COALESCE(repo_trends.stars, repos.stars)` |
+| Most active | `repo_trends.activity_score` |
+| Most used | `project_trends.monthly_downloads` |
+| Newest | `projects.created_at` |
+
+All descending, `NULLS LAST`, tie-broken by `slug ASC` for deterministic pagination.
+
+## How to tune
+
+1. Edit the formulas in `packages/db/src/{repo-trends,project-trends}/scoring.ts` and update the unit tests (`pnpm -F db test`)
+2. Recompute the stored scores: `pnpm -F backend daily-update-trends`
+3. Eyeball the result against real data: `bun run apps/backend/src/cli.ts check-trends-queries --sort trending` (see flags with `--help`; it also verifies the floor / sort-order / tag-filter invariants)
+
+## Decision log
+
+- **2026-07-18** — `usage_score` recalibrated from "100 at 10M downloads/month" to "100 at 2B/month" (score saturation caused alphabetical ties); **Most used** sort switched from `usage_score` to raw `monthly_downloads`; deprecated malus adjusted −20 → −17 to preserve the ~10M visibility threshold; `popularity_score` blend changed from `yearly + monthly*6 + daily*180` to `yearly + monthly*6` with a weekly/daily extrapolation fallback for repos tracked < 1 month (one-day GitHub star purges were dominating the score — the TanStack Query case).
+- **2026-05** (tasks 1–2, issues #422/#423) — initial scoring system per the [PRD](../prd/replace-static-api-with-db.md).

--- a/docs/prd/replace-static-api-with-db.md
+++ b/docs/prd/replace-static-api-with-db.md
@@ -1,5 +1,7 @@
 This is the PRD created from #371 using https://github.com/mattpocock/skills/blob/main/write-a-prd/SKILL.md
 
+> **Note:** this is a point-in-time document. The scoring formulas and sort keys have evolved since — see [docs/architecture/scoring.md](../architecture/scoring.md) for the current source of truth and the decision log.
+
 ## Problem Statement
 
 The web app loads a static `projects.json` (~2,000 projects) built once daily, queries it in-memory using `mingo`, and computes star trends per-request via `computeTrends()` on raw snapshots. This has hard limits:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Best of JS monorepo",
   "scripts": {
     "backup": "NODE_ENV=production bun run ./apps/backend/src/backup/make-backup.ts",
+    "restore": "dotenv -e .env.development -- bun run ./apps/backend/src/backup/restore-backup.ts",
     "build": "turbo run build -F=!legacy",
     "lint": "turbo run lint -F=!legacy",
     "typecheck": "turbo run typecheck -F=!legacy",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -41,3 +41,13 @@ To generate migration files after updating the schema file (this will run `drizz
 ```sh
 pnpm -F db generate
 ```
+
+## Tests
+
+Unit tests cover the pure functions (scoring formulas, snapshot logic) and never touch the database:
+
+```sh
+pnpm -F db test
+```
+
+Database queries are checked manually against real data (local or production) with the `check-trends-queries` task in `apps/backend` — see the backend README.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
     "migrate": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit migrate",
     "push": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit push",
     "studio": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit studio",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch",
     "lint": "biome check ./src",

--- a/packages/db/src/project-trends/scoring.test.ts
+++ b/packages/db/src/project-trends/scoring.test.ts
@@ -2,20 +2,28 @@ import { computeRelevanceScore, computeUsageScore } from "./scoring";
 import { describe, expect, test } from "bun:test";
 
 describe("computeUsageScore", () => {
-  test("anchor: 10M downloads → 100", () => {
-    expect(computeUsageScore(10_000_000)).toBeCloseTo(100, 6);
+  test("anchor: 2B downloads → 100 (the ceiling)", () => {
+    expect(computeUsageScore(2_000_000_000)).toBeCloseTo(100, 6);
   });
 
-  test("anchor: 1M downloads → 80", () => {
-    expect(computeUsageScore(1_000_000)).toBeCloseTo(80, 6);
+  test("anchor: 1B downloads → ~96", () => {
+    expect(computeUsageScore(1_000_000_000)).toBeCloseTo(95.88, 1);
   });
 
-  test("anchor: 100k downloads → 60", () => {
-    expect(computeUsageScore(100_000)).toBeCloseTo(60, 6);
+  test("anchor: 100M downloads → ~82", () => {
+    expect(computeUsageScore(100_000_000)).toBeCloseTo(82.18, 1);
   });
 
-  test("anchor: 10k downloads → 40", () => {
-    expect(computeUsageScore(10_000)).toBeCloseTo(40, 6);
+  test("anchor: 10M downloads → ~68", () => {
+    expect(computeUsageScore(10_000_000)).toBeCloseTo(68.48, 1);
+  });
+
+  test("anchor: 1M downloads → ~55", () => {
+    expect(computeUsageScore(1_000_000)).toBeCloseTo(54.79, 1);
+  });
+
+  test("anchor: 10k downloads → ~27", () => {
+    expect(computeUsageScore(10_000)).toBeCloseTo(27.39, 1);
   });
 
   test("clamps below 100 floor (no/zero downloads → 0)", () => {
@@ -25,9 +33,9 @@ describe("computeUsageScore", () => {
     expect(computeUsageScore(50)).toBe(0); // below 100, clamped to 0
   });
 
-  test("clamps above 10M ceiling (>10M → 100)", () => {
-    expect(computeUsageScore(100_000_000)).toBe(100);
-    expect(computeUsageScore(1_000_000_000)).toBe(100);
+  test("clamps above the 2B ceiling", () => {
+    expect(computeUsageScore(5_000_000_000)).toBe(100);
+    expect(computeUsageScore(20_000_000_000)).toBe(100);
   });
 
   test("monotonic — more downloads ranks higher", () => {
@@ -68,7 +76,7 @@ describe("computeRelevanceScore", () => {
     expect(score).toBeCloseTo(73, 6);
   });
 
-  test("deprecated malus is exactly -20", () => {
+  test("deprecated malus is exactly -17", () => {
     const inputs = {
       popularityScore: 50,
       activityScore: 50,
@@ -76,18 +84,29 @@ describe("computeRelevanceScore", () => {
     } as const;
     const active = computeRelevanceScore(inputs);
     const deprecated = computeRelevanceScore({ ...inputs, isDeprecated: true });
-    expect(active - deprecated).toBeCloseTo(20, 6);
+    expect(active - deprecated).toBeCloseTo(17, 6);
   });
 
-  test("deprecated with strong NPM usage clears the floor (≥ 0)", () => {
-    // 10M downloads → usage 100, no popularity/activity, deprecated
+  test("deprecated with strong NPM usage (~10M downloads) clears the floor (≥ 0)", () => {
+    // usage 68 ≈ 10M monthly downloads, no popularity/activity, deprecated
     const score = computeRelevanceScore({
       popularityScore: 0,
       activityScore: 0,
-      usageScore: 100,
+      usageScore: 68,
       isDeprecated: true,
     });
-    expect(score).toBeGreaterThanOrEqual(0); // 0 + 0 + 25 - 20 = 5
+    expect(score).toBeGreaterThanOrEqual(0); // 0 + 0 + 17 - 17 = 0
+  });
+
+  test("deprecated with moderate NPM usage falls below the floor", () => {
+    // usage 60 ≈ 2.4M monthly downloads
+    const score = computeRelevanceScore({
+      popularityScore: 0,
+      activityScore: 0,
+      usageScore: 60,
+      isDeprecated: true,
+    });
+    expect(score).toBeLessThan(0); // 0 + 0 + 15 - 17 = -2
   });
 
   test("deprecated with no signal falls below the floor", () => {

--- a/packages/db/src/project-trends/scoring.ts
+++ b/packages/db/src/project-trends/scoring.ts
@@ -1,14 +1,20 @@
 /**
- * Log10 of monthly downloads, scaled into 0–100. Used as the sort key for "most used".
+ * Log10 of monthly downloads, scaled into 0–100. Feeds the relevance blend;
+ * the "most used" sort uses raw monthly downloads, not this score.
  *
- * score = max(0, min(100, (log10(downloads) - 2) * 20))
+ * score = max(0, min(100, (log10(downloads) - 2) * slope))
  *
- * Anchors: 100 downloads → 0, 10k → 40, 100k → 60, 1M → 80, 10M → 100.
+ * The slope is calibrated so that 100 downloads → 0 and 2 billion → 100,
+ * the ceiling only the most downloaded npm packages approach.
+ * Anchors: 10k → ~27, 1M → ~55, 10M → ~68, 100M → ~82, 1B → ~96.
  * No or zero downloads → 0.
  */
+const MAX_MONTHLY_DOWNLOADS = 2_000_000_000;
+const USAGE_SLOPE = 100 / (Math.log10(MAX_MONTHLY_DOWNLOADS) - 2);
+
 export function computeUsageScore(monthlyDownloads: number | null | undefined) {
   if (!monthlyDownloads || monthlyDownloads <= 0) return 0;
-  const raw = (Math.log10(monthlyDownloads) - 2) * 20;
+  const raw = (Math.log10(monthlyDownloads) - 2) * USAGE_SLOPE;
   return Math.max(0, Math.min(100, raw));
 }
 
@@ -19,7 +25,8 @@ export function computeUsageScore(monthlyDownloads: number | null | undefined) {
  *
  *   with package:    0.50 * popularity + 0.25 * activity + 0.25 * usage
  *   no package:      0.65 * popularity + 0.35 * activity
- *   minus 20 if deprecated.
+ *   minus 17 if deprecated — calibrated so a deprecated project needs
+ *   usage ≥ 68 (~10M monthly downloads) to stay above the `>= 0` floor.
  */
 export function computeRelevanceScore({
   popularityScore,
@@ -36,5 +43,5 @@ export function computeRelevanceScore({
   const blend = hasPackage
     ? popularityScore * 0.5 + activityScore * 0.25 + usageScore * 0.25
     : popularityScore * 0.65 + activityScore * 0.35;
-  return isDeprecated ? blend - 20 : blend;
+  return isDeprecated ? blend - 17 : blend;
 }

--- a/packages/db/src/projects/find-with-trends.ts
+++ b/packages/db/src/projects/find-with-trends.ts
@@ -1,0 +1,145 @@
+import { and, count, eq, gte, type SQL, sql } from "drizzle-orm";
+
+import type { DB } from "../index";
+import * as schema from "../schema";
+import type { TrendsSortKey } from "../shared-schemas";
+import { getWhereClauseSearchByTag, getWhereClauseSearchByText } from "./find";
+
+const { projects, projectTrends, projectsToTags, repos, repoTrends, tags } =
+  schema;
+
+/**
+ * Deprecated projects have no `repo_trends` row (deleted by the daily cleanup
+ * task), so fall back to the canonical GitHub star count from `repos`.
+ */
+const starsExpression = sql<number>`COALESCE(${repoTrends.stars}, ${repos.stars})`;
+
+const sortExpressionByKey: Record<TrendsSortKey, SQL> = {
+  trending: sql`${repoTrends.popularityScore}`,
+  "hot-today": sql`${repoTrends.daily}`,
+  "most-stars": starsExpression,
+  "most-active": sql`${repoTrends.activityScore}`,
+  // raw downloads, not `usage_score`: the log-scale score buckets projects
+  // together (ties), raw counts give an exact order
+  "most-used": sql`${projectTrends.monthlyDownloads}`,
+  newest: sql`${projects.createdAt}`,
+};
+
+export interface FindProjectsWithTrendsOptions {
+  db: DB;
+  limit?: number;
+  page?: number;
+  /** Text search on project name/description and repo owner/name */
+  query?: string;
+  /**
+   * Quality floor: keep only projects with `relevance_score >= 0`.
+   * Disable to query the full catalog, including deprecated projects
+   * with no meaningful signals (used by the `/search` route).
+   */
+  relevanceFloor?: boolean;
+  sort?: TrendsSortKey;
+  /** Keep only projects that have ALL the requested tags */
+  tagCodes?: string[];
+}
+
+export type ProjectWithTrends = Awaited<
+  ReturnType<typeof findProjectsWithTrends>
+>["projects"][number];
+
+/**
+ * Web-facing variant of `findProjects()`, backed by the `repo_trends` and
+ * `project_trends` cache tables populated daily by the backend tasks.
+ * Projects added since the last daily run have no cache row and are not
+ * returned; the admin app should keep using `findProjects()`.
+ */
+export async function findProjectsWithTrends({
+  db,
+  limit = 30,
+  page = 1,
+  query,
+  relevanceFloor = true,
+  sort = "trending",
+  tagCodes,
+}: FindProjectsWithTrendsOptions) {
+  const offset = (page - 1) * limit;
+
+  const where = and(
+    relevanceFloor ? gte(projectTrends.relevanceScore, 0) : undefined,
+    query ? getWhereClauseSearchByText(query) : undefined,
+    tagCodes && tagCodes.length > 0
+      ? getWhereClauseSearchByTag(db, tagCodes)
+      : undefined,
+  );
+
+  const projectsQuery = db
+    .select({
+      slug: projects.slug,
+      name: projects.name,
+      description: projects.description,
+      url: projects.url,
+      createdAt: projects.createdAt,
+      status: projects.status,
+      logo: projects.logo,
+      tags: sql<
+        string[]
+      >`COALESCE(json_agg(distinct ${tags.code}) FILTER (WHERE ${tags.code} IS NOT NULL), '[]')`, // avoid [null], return empty arrays instead
+      repo: {
+        full_name: sql<string>`${repos.owner} || '/' || ${repos.name}`,
+        owner_id: repos.owner_id,
+        archived: repos.archived,
+        last_commit: repos.last_commit,
+        contributor_count: repos.contributor_count,
+      },
+      stars: starsExpression,
+      trends: {
+        daily: repoTrends.daily,
+        weekly: repoTrends.weekly,
+        monthly: repoTrends.monthly,
+        quarterly: repoTrends.quarterly,
+        yearly: repoTrends.yearly,
+      },
+      popularityScore: repoTrends.popularityScore,
+      activityScore: repoTrends.activityScore,
+      usageScore: projectTrends.usageScore,
+      relevanceScore: projectTrends.relevanceScore,
+      packageName: projectTrends.packageName,
+      monthlyDownloads: projectTrends.monthlyDownloads,
+    })
+    .from(projects)
+    .innerJoin(repos, eq(projects.repoId, repos.id))
+    .innerJoin(projectTrends, eq(projectTrends.projectId, projects.id))
+    .leftJoin(repoTrends, eq(repoTrends.repoId, repos.id))
+    .leftJoin(projectsToTags, eq(projectsToTags.projectId, projects.id))
+    .leftJoin(tags, eq(projectsToTags.tagId, tags.id))
+    .where(where)
+    .groupBy(projects.id, repos.id, repoTrends.repoId, projectTrends.projectId)
+    .orderBy(...getOrderByQuery(sort))
+    .limit(limit)
+    .offset(offset);
+
+  const totalQuery = db
+    .select({ count: count() })
+    .from(projects)
+    .innerJoin(repos, eq(projects.repoId, repos.id))
+    .innerJoin(projectTrends, eq(projectTrends.projectId, projects.id))
+    .leftJoin(repoTrends, eq(repoTrends.repoId, repos.id))
+    .where(where);
+
+  const [foundProjects, totalResults] = await Promise.all([
+    projectsQuery,
+    totalQuery,
+  ]);
+
+  return { projects: foundProjects, total: totalResults[0].count };
+}
+
+function getOrderByQuery(sort: TrendsSortKey) {
+  const expression = sortExpressionByKey[sort];
+  return [
+    // Every sort option is descending; `NULLS LAST` keeps projects without
+    // a `repo_trends` row (deprecated) at the bottom instead of the top.
+    sql`${expression} desc nulls last`,
+    // Tiebreaker to make pagination deterministic
+    sql`${projects.slug} asc`,
+  ];
+}

--- a/packages/db/src/projects/find.ts
+++ b/packages/db/src/projects/find.ts
@@ -122,7 +122,7 @@ export async function findProjects({
 }
 
 /** Select project IDs that have ALL the requested tags */
-function getWhereClauseSearchByTag(db: DB, tagCodes: string[]) {
+export function getWhereClauseSearchByTag(db: DB, tagCodes: string[]) {
   return inArray(
     projects.id,
     db
@@ -135,7 +135,7 @@ function getWhereClauseSearchByTag(db: DB, tagCodes: string[]) {
   );
 }
 
-function getWhereClauseSearchByText(text: string) {
+export function getWhereClauseSearchByText(text: string) {
   return or(
     ilike(projects.name, `%${text}%`),
     ilike(projects.description, `%${text}%`),

--- a/packages/db/src/projects/index.ts
+++ b/packages/db/src/projects/index.ts
@@ -1,6 +1,7 @@
 export * from "./create";
 export * from "./find";
 export * from "./find-featured";
+export * from "./find-with-trends";
 export * from "./get";
 export * from "./packages";
 export * from "./project-helpers";

--- a/packages/db/src/projects/project-helpers.ts
+++ b/packages/db/src/projects/project-helpers.ts
@@ -3,7 +3,8 @@ import slugify from "slugify";
 import invariant from "tiny-invariant";
 
 import { TAGS_EXCLUDED_FROM_RANKINGS } from "../constants";
-import { computeTrends, getMonthlyTrends } from "../snapshots/index";
+import { computeTrends } from "../snapshots/compute-trends";
+import { getMonthlyTrends } from "../snapshots/monthly-trends";
 import type { OneYearSnapshots, ProjectDetails } from ".";
 
 export function getProjectDescription(project: ProjectDetails) {

--- a/packages/db/src/repo-trends/scoring.test.ts
+++ b/packages/db/src/repo-trends/scoring.test.ts
@@ -60,6 +60,37 @@ describe("computePopularityScore", () => {
     });
     expect(a).toBeCloseTo(b, 6);
   });
+
+  test("a one-day spike or purge does not affect the score", () => {
+    // TanStack Query profile: -30 stars yesterday (spam purge) but healthy
+    // monthly/yearly growth — the daily delta must be ignored
+    const purgeDay = computePopularityScore({
+      daily: -30,
+      weekly: -16,
+      monthly: 164,
+      yearly: 4100,
+    });
+    const normalDay = computePopularityScore({
+      daily: 26,
+      weekly: 180,
+      monthly: 164,
+      yearly: 4100,
+    });
+    expect(purgeDay).toBeCloseTo(normalDay, 6);
+    expect(purgeDay).toBeGreaterThan(50);
+  });
+
+  test("young repo without monthly data: extrapolates from weekly", () => {
+    const estimated = computePopularityScore({ daily: 100, weekly: 250 });
+    const fullMonth = computePopularityScore({ monthly: 1000 });
+    expect(estimated).toBeCloseTo(fullMonth, 6);
+  });
+
+  test("young repo on day one: extrapolates from daily", () => {
+    const score = computePopularityScore({ daily: 40 });
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeCloseTo(computePopularityScore({ monthly: 1200 }), 6);
+  });
 });
 
 describe("computeActivityScore", () => {

--- a/packages/db/src/repo-trends/scoring.ts
+++ b/packages/db/src/repo-trends/scoring.ts
@@ -1,23 +1,35 @@
 type RepoTrendDeltas = {
-  daily?: number;
-  monthly?: number;
-  yearly?: number;
+  daily?: number | null;
+  weekly?: number | null;
+  monthly?: number | null;
+  yearly?: number | null;
 };
 
 /**
- * Signed log-scale blend of star momentum across daily, monthly, and yearly windows.
+ * Signed log-scale blend of star momentum over the monthly and yearly windows.
  * Range ~ -100 to +100. Used as the sort key for "trending".
  *
- * raw = yearly + monthly*6 + daily*180
+ * raw = yearly + monthly*6
  * score = sign(raw) * log10(1 + |raw| / 10) * 30
+ *
+ * Daily and weekly deltas are deliberately excluded: GitHub stars have
+ * mysterious one-day spikes (spam-account purges, viral bursts) that would
+ * otherwise outweigh a whole year of genuine growth. They are only used as
+ * a fallback for repos tracked for less than a month (no monthly delta yet),
+ * extrapolating the freshest window available: weekly*4, then daily*30.
  */
 export function computePopularityScore(trends: RepoTrendDeltas): number {
   const yearly = trends.yearly ?? 0;
-  const monthly = trends.monthly ?? 0;
-  const daily = trends.daily ?? 0;
-  const raw = yearly + monthly * 6 + daily * 180;
+  const monthly = trends.monthly ?? estimateMonthlyDelta(trends);
+  const raw = yearly + monthly * 6;
   if (raw === 0) return 0;
   return Math.sign(raw) * Math.log10(1 + Math.abs(raw) / 10) * 30;
+}
+
+function estimateMonthlyDelta({ weekly, daily }: RepoTrendDeltas): number {
+  if (weekly != null) return weekly * 4;
+  if (daily != null) return daily * 30;
+  return 0;
 }
 
 type ActivityInputs = {

--- a/packages/db/src/shared-schemas.ts
+++ b/packages/db/src/shared-schemas.ts
@@ -19,3 +19,15 @@ export const findProjectsSortSchema = z.array(
 );
 
 export type ProjectsSortableColumnName = z.infer<typeof columnIdsSchema>;
+
+/** Sort options for the trends-backed queries used by the public web app */
+export const trendsSortKeySchema = z.enum([
+  "trending",
+  "hot-today",
+  "most-stars",
+  "most-active",
+  "most-used",
+  "newest",
+]);
+
+export type TrendsSortKey = z.infer<typeof trendsSortKeySchema>;

--- a/packages/db/src/snapshots/snapshots.ts
+++ b/packages/db/src/snapshots/snapshots.ts
@@ -3,11 +3,8 @@ import { and, eq } from "drizzle-orm";
 import { groupBy, isEqual, orderBy, pick } from "es-toolkit";
 
 import type { DB } from "..";
-import {
-  flattenSnapshots,
-  type MonthSnapshots,
-  type OneYearSnapshots,
-} from "../projects";
+import type { MonthSnapshots, OneYearSnapshots } from "../projects";
+import { flattenSnapshots } from "../projects/project-helpers";
 import * as schema from "../schema";
 import type { Snapshot } from "./types";
 import { normalizeDate } from "./utils";


### PR DESCRIPTION
## Goal

Step 3 of the DB-driven rankings migration (#424): data layer ready for the web app cutover.

- New `findProjectsWithTrends()` in `@repo/db`: joins the `repo_trends` + `project_trends` cache tables, 6 sort options, `relevance_score >= 0` quality floor (opt-out for the future `/search` route), tag AND filter, text search, pagination. `LEFT JOIN repo_trends` + `NULLS LAST` + `COALESCE` stars keep deprecated-but-widely-used projects listed.
- Scoring adjustments after validation on real data — see `docs/architecture/scoring.md` (new doc + decision log): popularity ignores noisy daily/weekly star deltas, usage score recalibrated (100 = 2B downloads/month), deprecated malus −20 → −17, "Most used" sorts by raw `monthly_downloads`.
- New `check-trends-queries` backend task to test the queries manually, plus updated scoring unit tests.
- New `restore-backup` script to restore the local DB from a dump.

## How to test

```sh
pnpm -F db test                       # scoring unit tests
pnpm -F backend daily-update-trends   # recompute the stored scores
bun run apps/backend/src/cli.ts check-trends-queries --sort trending --tags react
```

`check-trends-queries` prints the listing results and verifies the invariants (relevance floor, `NULLS LAST` sort order, tag-AND filter) — it warns if any is violated. Flags: `--sort`, `--tags`, `--search`, `--fullCatalog`, `--columns`, `--page`.

<img width="850" height="548" alt="image" src="https://github.com/user-attachments/assets/b3ee902d-9963-4d04-9d89-68a0df413d48" />

