### PR TITLE
Task 4/7: Migrate /projects page to DB-backed queries

### DIFF
--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -30,7 +30,7 @@ export const checkTrendsQueriesTask = createTask({
     sort: {
       type: String,
       description:
-        "Sort option: trending, daily, weekly, monthly, yearly, most-stars, most-active, most-used, newest",
+        "Sort option: trending, daily, weekly, monthly, yearly, most-stars, most-active, last-commit, contributors, monthly-downloads, created, newest",
       default: "most-stars",
     },
     tags: {
@@ -152,7 +152,11 @@ function checkRelevanceFloor(
     );
 }
 
+// "created" means oldest-GitHub-repo-first; every other sort is descending.
+const ASCENDING_SORT_KEYS: TrendsSortKey[] = ["created"];
+
 function checkSortOrder(projects: ProjectWithTrends[], sort: TrendsSortKey) {
+  const ascending = ASCENDING_SORT_KEYS.includes(sort);
   const violations: string[] = [];
   let previous: number | undefined;
   let seenNull = false;
@@ -168,10 +172,13 @@ function checkSortOrder(projects: ProjectWithTrends[], sort: TrendsSortKey) {
       );
       continue;
     }
-    if (previous !== undefined && value > previous) {
-      violations.push(
-        `"${project.slug}" (${value}) is ranked after a project with a lower "${sort}" value (${previous})`,
-      );
+    if (previous !== undefined) {
+      const outOfOrder = ascending ? value < previous : value > previous;
+      if (outOfOrder) {
+        violations.push(
+          `"${project.slug}" (${value}) is ranked after a project with a ${ascending ? "higher" : "lower"} "${sort}" value (${previous})`,
+        );
+      }
     }
     previous = value;
   }
@@ -194,8 +201,14 @@ function getSortValue(project: ProjectWithTrends, sort: TrendsSortKey) {
       return project.stars;
     case "most-active":
       return project.activityScore;
-    case "most-used":
+    case "last-commit":
+      return project.repo.last_commit?.getTime() ?? null;
+    case "contributors":
+      return project.repo.contributor_count ?? null;
+    case "monthly-downloads":
       return project.monthlyDownloads;
+    case "created":
+      return project.repo.created_at.getTime();
     case "newest":
       return project.createdAt.getTime();
   }
@@ -236,6 +249,11 @@ const COLUMNS = {
   popularity: (p: ProjectWithTrends) => roundScore(p.popularityScore),
   activity: (p: ProjectWithTrends) => roundScore(p.activityScore),
   usage: (p: ProjectWithTrends) => roundScore(p.usageScore),
+  contributors: (p: ProjectWithTrends) => p.repo.contributor_count,
+  lastCommit: (p: ProjectWithTrends) =>
+    p.repo.last_commit?.toISOString().slice(0, 10) ?? null,
+  createdAt: (p: ProjectWithTrends) =>
+    p.repo.created_at.toISOString().slice(0, 10),
   tags: (p: ProjectWithTrends) => p.tags.join(", "),
 } as const satisfies Record<
   string,

--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -30,8 +30,8 @@ export const checkTrendsQueriesTask = createTask({
     sort: {
       type: String,
       description:
-        "Sort option: trending, hot-today, most-stars, most-active, most-used, newest",
-      default: "trending",
+        "Sort option: trending, daily, weekly, monthly, yearly, most-stars, most-active, most-used, newest",
+      default: "most-stars",
     },
     tags: {
       type: String,
@@ -60,7 +60,7 @@ export const checkTrendsQueriesTask = createTask({
     },
   },
   schema: z.object({
-    sort: trendsSortKeySchema.optional().default("trending"),
+    sort: trendsSortKeySchema.optional().default("most-stars"),
     tags: z.string().optional(),
     search: z.string().optional(),
     fullCatalog: z.boolean().optional().default(false),
@@ -182,8 +182,14 @@ function getSortValue(project: ProjectWithTrends, sort: TrendsSortKey) {
   switch (sort) {
     case "trending":
       return project.popularityScore;
-    case "hot-today":
+    case "daily":
       return project.trends?.daily ?? null;
+    case "weekly":
+      return project.trends?.weekly ?? null;
+    case "monthly":
+      return project.trends?.monthly ?? null;
+    case "yearly":
+      return project.trends?.yearly ?? null;
     case "most-stars":
       return project.stars;
     case "most-active":

--- a/apps/backend/src/tasks/trigger-build-webapp.task.ts
+++ b/apps/backend/src/tasks/trigger-build-webapp.task.ts
@@ -12,6 +12,9 @@ export const triggerBuildWebappTask = createTask({
     const tags = [
       "daily",
       "all-projects",
+      // DB-backed /projects page + /api/og/projects OG route (migrated off
+      // the static-JSON "all-projects" tag in #424).
+      "projects",
       "project-details",
       "package-downloads",
     ];

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -28,6 +28,7 @@ import {
   getTrendsSortOptionByKey,
   type TrendsSortOption,
 } from "@/components/project-list/trends-sort-order-options";
+import { fromNow } from "@/helpers/from-now";
 import { formatNumber } from "@/helpers/numbers";
 import { getSearchParamsKeyValues } from "@/lib/url-search-params";
 
@@ -191,7 +192,10 @@ function ProjectScore({
     case "yearly":
       return <ShowStarsAverage value={getDeltaByDay("yearly")(project)} />;
     case "most-active":
-      return <Box>{pushed_at}</Box>;
+      // No `last_commit` (nullable, e.g. GraphQL commit-history lookup
+      // skipped/failed) → same "fully inactive" state `computeActivityScore`
+      // treats as 0, so nothing to show rather than "Invalid Date".
+      return pushed_at ? <Box>{fromNow(pushed_at)}</Box> : null;
     case "contributors":
       return <Box>{formatNumber(contributor_count, "compact")}</Box>;
     case "monthly-downloads":

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -170,7 +170,7 @@ function ProjectScore({
   project: TrendsProject;
   sortOptionKey: TrendsSortKey;
 }) {
-  const { created_at, pushed_at, contributor_count, downloads, trends } =
+  const { added_at, pushed_at, contributor_count, downloads, trends } =
     project;
   switch (sortOptionKey) {
     case "trending": {
@@ -201,7 +201,7 @@ function ProjectScore({
     case "monthly-downloads":
       return <Box>{formatNumber(downloads, "compact")}</Box>;
     case "newest":
-      return <Box>{created_at}</Box>;
+      return <Box>{added_at}</Box>;
     default: // "most-stars", "last-commit", "created"
       return <ShowStarsTotal value={project.stars} />;
   }

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -1,3 +1,10 @@
+import { cacheLife, cacheTag } from "next/cache";
+
+import { db } from "@repo/db";
+import { findProjectsWithTrends } from "@repo/db/projects";
+import type { TrendsSortKey } from "@repo/db/shared-schemas";
+import { findTags } from "@repo/db/tags";
+
 import {
   Box,
   generateImageResponse,
@@ -7,34 +14,32 @@ import {
   StarIcon,
   TagIcon,
 } from "@/app/api/og/og-utils";
-import { ProjectSearchStateParser } from "@/app/projects/project-search-state";
+import {
+  buildTagsByCode,
+  type TrendsProject,
+  toTrendsProject,
+} from "@/app/projects/project-adapter";
+import {
+  type TrendsProjectSearchState,
+  TrendsProjectSearchStateParser,
+} from "@/app/projects/trends-project-search-state";
 import { getDeltaByDay } from "@/components/core";
 import {
-  getSortOptionByKey,
-  type SortOption,
-  type SortOptionKey,
-} from "@/components/project-list/sort-order-options";
+  getTrendsSortOptionByKey,
+  type TrendsSortOption,
+} from "@/components/project-list/trends-sort-order-options";
 import { formatNumber } from "@/helpers/numbers";
 import { getSearchParamsKeyValues } from "@/lib/url-search-params";
-import { api } from "@/server/api-remote-json";
 
 import { ImageLayout } from "../og-image-layout";
 
-const searchStateParser = new ProjectSearchStateParser();
+const searchStateParser = new TrendsProjectSearchStateParser();
 
 export async function GET(req: Request) {
-  const NUMBER_OF_PROJECTS = 3;
-  const {
-    searchState: { tags, query, sort, page },
-  } = getSearchStateFromURL(req.url);
-  const sortOption = getSortOptionByKey(sort);
-  const { projects, selectedTags } = await api.projects.findProjects({
-    criteria: tags.length > 0 ? { tags: { $all: tags } } : {},
-    query,
-    sort: sortOption.sort,
-    skip: NUMBER_OF_PROJECTS * (page - 1),
-    limit: NUMBER_OF_PROJECTS,
-  });
+  const { searchState } = getSearchStateFromURL(req.url);
+  const { query, sort } = searchState;
+  const sortOption = getTrendsSortOptionByKey(sort);
+  const { projects, selectedTags } = await fetchOgProjects(searchState);
 
   return generateImageResponse(
     <ImageLayout>
@@ -59,7 +64,34 @@ export async function GET(req: Request) {
   );
 }
 
-function getImageTitle(tags: BestOfJS.Tag[], query?: string) {
+async function fetchOgProjects(searchState: TrendsProjectSearchState) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("projects");
+
+  const NUMBER_OF_PROJECTS = 3;
+  const { tags: tagCodes, query, sort, page } = searchState;
+
+  const [{ projects: rows }, allTags] = await Promise.all([
+    findProjectsWithTrends({
+      db,
+      limit: NUMBER_OF_PROJECTS,
+      page,
+      query,
+      sort,
+      tagCodes,
+    }),
+    findTags(),
+  ]);
+
+  const tagsByCode = buildTagsByCode(allTags);
+  const projects = rows.map((row) => toTrendsProject(row, tagsByCode));
+  const selectedTags = allTags.filter((tag) => tagCodes.includes(tag.code));
+
+  return { projects, selectedTags };
+}
+
+function getImageTitle(tags: { name: string }[], query?: string) {
   if (!query && tags.length === 0) {
     return "All Projects";
   }
@@ -80,9 +112,9 @@ function ImageCaption({
   query,
   sortOption,
 }: {
-  tags: BestOfJS.Tag[];
+  tags: { name: string }[];
   query?: string;
-  sortOption: SortOption;
+  sortOption: TrendsSortOption;
 }) {
   return (
     <Box style={{ gap: 16, alignItems: "center" }}>
@@ -106,8 +138,8 @@ function ProjectRow({
   sortOption,
   index,
 }: {
-  project: BestOfJS.Project;
-  sortOption: SortOption;
+  project: TrendsProject;
+  sortOption: TrendsSortOption;
   index: number;
 }) {
   return (
@@ -134,34 +166,36 @@ function ProjectScore({
   project,
   sortOptionKey,
 }: {
-  project: BestOfJS.Project;
-  sortOptionKey: SortOptionKey;
+  project: TrendsProject;
+  sortOptionKey: TrendsSortKey;
 }) {
-  const { contributor_count, created_at, downloads, trends } = project;
+  const { created_at, pushed_at, downloads, trends } = project;
   switch (sortOptionKey) {
+    case "trending": {
+      // Same freshest-window fallback used in the /projects table: no single
+      // raw signal maps 1:1 to the blended popularity score.
+      const value = trends.yearly ?? trends.monthly ?? trends.daily;
+      return value !== undefined ? (
+        <ShowStarsTotal value={value} showPrefix />
+      ) : null;
+    }
     case "daily":
       return trends.daily ? (
         <ShowStarsTotal value={trends.daily} showPrefix />
       ) : null;
     case "weekly":
-      return trends.weekly ? (
-        <ShowStarsAverage value={getDeltaByDay("weekly")(project)} />
-      ) : null;
+      return <ShowStarsAverage value={getDeltaByDay("weekly")(project)} />;
     case "monthly":
-      return trends.monthly ? (
-        <ShowStarsAverage value={getDeltaByDay("monthly")(project)} />
-      ) : null;
+      return <ShowStarsAverage value={getDeltaByDay("monthly")(project)} />;
     case "yearly":
-      return trends.yearly ? (
-        <ShowStarsAverage value={getDeltaByDay("yearly")(project)} />
-      ) : null;
-    case "monthly-downloads":
+      return <ShowStarsAverage value={getDeltaByDay("yearly")(project)} />;
+    case "most-active":
+      return <Box>{pushed_at}</Box>;
+    case "most-used":
       return <Box>{formatNumber(downloads, "compact")}</Box>;
-    case "contributors":
-      return <Box>{formatNumber(contributor_count, "compact")}</Box>;
-    case "created":
+    case "newest":
       return <Box>{created_at}</Box>;
-    default:
+    default: // "most-stars"
       return <ShowStarsTotal value={project.stars} />;
   }
 }

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -169,7 +169,8 @@ function ProjectScore({
   project: TrendsProject;
   sortOptionKey: TrendsSortKey;
 }) {
-  const { created_at, pushed_at, downloads, trends } = project;
+  const { created_at, pushed_at, contributor_count, downloads, trends } =
+    project;
   switch (sortOptionKey) {
     case "trending": {
       // Same freshest-window fallback used in the /projects table: no single
@@ -191,11 +192,13 @@ function ProjectScore({
       return <ShowStarsAverage value={getDeltaByDay("yearly")(project)} />;
     case "most-active":
       return <Box>{pushed_at}</Box>;
-    case "most-used":
+    case "contributors":
+      return <Box>{formatNumber(contributor_count, "compact")}</Box>;
+    case "monthly-downloads":
       return <Box>{formatNumber(downloads, "compact")}</Box>;
     case "newest":
       return <Box>{created_at}</Box>;
-    default: // "most-stars"
+    default: // "most-stars", "last-commit", "created"
       return <ShowStarsTotal value={project.stars} />;
   }
 }

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -170,8 +170,7 @@ function ProjectScore({
   project: TrendsProject;
   sortOptionKey: TrendsSortKey;
 }) {
-  const { added_at, pushed_at, contributor_count, downloads, trends } =
-    project;
+  const { added_at, pushed_at, contributor_count, downloads, trends } = project;
   switch (sortOptionKey) {
     case "trending": {
       // Same freshest-window fallback used in the /projects table: no single

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -182,7 +182,7 @@ function ProjectScore({
       ) : null;
     }
     case "daily":
-      return trends.daily ? (
+      return trends.daily !== undefined ? (
         <ShowStarsTotal value={trends.daily} showPrefix />
       ) : null;
     case "weekly":

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -1,40 +1,48 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import NextLink from "next/link";
 
+import { db } from "@repo/db";
+import { findProjectsWithTrends } from "@repo/db/projects";
+import { findRelevantTags, findTags } from "@repo/db/tags";
+
+import {
+  buildTagsByCode,
+  type TrendsProject,
+  toTrendsProject,
+} from "@/app/projects/project-adapter";
 import { PlusIcon, TagIcon, XMarkIcon } from "@/components/core";
 import { PageHeading } from "@/components/core/typography";
-import { ProjectPaginatedList } from "@/components/project-list/project-paginated-list";
-import { getSortOptionByKey } from "@/components/project-list/sort-order-options";
+import { TrendsProjectPaginatedList } from "@/components/project-list/trends-project-paginated-list";
+import { getTrendsSortOptionByKey } from "@/components/project-list/trends-sort-order-options";
 import { badgeVariants } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { formatNumber } from "@/helpers/numbers";
-import { addCacheBustingParam } from "@/helpers/url";
 import { cn } from "@/lib/utils";
-import { api } from "@/server/api";
 
 import { ProjectListLoading } from "./loading-state";
 import {
-  type ProjectSearchState,
-  ProjectSearchStateParser,
-  type ProjectSearchUrlBuilder,
-} from "./project-search-state";
+  type TrendsProjectSearchState,
+  TrendsProjectSearchStateParser,
+  type TrendsProjectSearchUrlBuilder,
+} from "./trends-project-search-state";
+
+type TagSummary = { code: string; name: string };
 
 type ProjectsPageData = {
-  projects: BestOfJS.Project[];
+  projects: TrendsProject[];
   total: number;
-  selectedTags: BestOfJS.Tag[];
-  relevantTags: BestOfJS.Tag[];
-  allTags: BestOfJS.Tag[];
-  lastUpdateDate: Date;
+  selectedTags: TagSummary[];
+  relevantTags: TagSummary[];
 };
 
 type PageProps = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-const searchStateParser = new ProjectSearchStateParser();
+const searchStateParser = new TrendsProjectSearchStateParser();
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const searchParams = await props.searchParams;
@@ -45,14 +53,12 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const description = getPageDescription(data, searchState);
 
   const queryString = searchStateParser.stringify(searchState);
-  const urlSearchParams = new URLSearchParams(queryString);
-  addCacheBustingParam(urlSearchParams, data.lastUpdateDate);
 
   return {
     title,
     description,
     openGraph: {
-      images: [`api/og/projects/?${urlSearchParams.toString()}`],
+      images: [`api/og/projects/?${queryString}`],
       url: `${APP_CANONICAL_URL}/projects/?${queryString}`,
       title: `${title} • ${APP_DISPLAY_NAME}`,
       description,
@@ -60,7 +66,10 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   };
 }
 
-function getPageTitle(data: ProjectsPageData, searchState: ProjectSearchState) {
+function getPageTitle(
+  data: ProjectsPageData,
+  searchState: TrendsProjectSearchState,
+) {
   const { query } = searchState;
   const { selectedTags: tags } = data;
 
@@ -76,7 +85,7 @@ function getPageTitle(data: ProjectsPageData, searchState: ProjectSearchState) {
 
 function getPageDescription(
   data: ProjectsPageData,
-  searchState: ProjectSearchState,
+  searchState: TrendsProjectSearchState,
 ) {
   const { query, sort } = searchState;
   const NUMBER_OF_PROJECTS = 8;
@@ -86,8 +95,7 @@ function getPageDescription(
     .slice(0, NUMBER_OF_PROJECTS)
     .join(", ");
   const tagNames = tags.map((tag) => `“${tag.name}“`).join(" + ");
-  const sortOption = getSortOptionByKey(sort);
-  const sortOptionLabel = sortOption.label.toLowerCase();
+  const sortOptionLabel = getTrendsSortOptionByKey(sort).label.toLowerCase();
 
   if (!query && tags.length === 0) {
     return `All the ${total} projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`;
@@ -113,7 +121,7 @@ async function ProjectsPageContent(props: PageProps) {
   const searchParams = await props.searchParams;
 
   const { searchState, buildPageURL } = searchStateParser.parse(searchParams);
-  const { projects, total, selectedTags, relevantTags, allTags } =
+  const { projects, total, selectedTags, relevantTags } =
     await fetchPageData(searchState);
 
   const { query } = searchState;
@@ -129,7 +137,6 @@ async function ProjectsPageContent(props: PageProps) {
         <CurrentTags
           tags={selectedTags}
           buildPageURL={buildPageURL}
-          allTags={allTags}
           textQuery={query}
         />
       )}
@@ -140,7 +147,7 @@ async function ProjectsPageContent(props: PageProps) {
           showIcon={selectedTags.length > 0}
         />
       )}
-      <ProjectPaginatedList
+      <TrendsProjectPaginatedList
         projects={projects}
         total={total}
         searchState={searchState}
@@ -155,8 +162,8 @@ function ProjectPageHeader({
   searchState,
   total,
 }: {
-  tags: BestOfJS.Tag[];
-  searchState: ProjectSearchState;
+  tags: TagSummary[];
+  searchState: TrendsProjectSearchState;
   total: number;
 }) {
   const { query } = searchState;
@@ -217,8 +224,8 @@ function RelevantTags({
   showIcon,
   limit = 16,
 }: {
-  tags: BestOfJS.Tag[];
-  buildPageURL: ProjectSearchUrlBuilder;
+  tags: TagSummary[];
+  buildPageURL: TrendsProjectSearchUrlBuilder;
   showIcon?: boolean;
   limit?: number;
 }) {
@@ -250,9 +257,8 @@ function CurrentTags({
   textQuery,
   buildPageURL,
 }: {
-  tags: BestOfJS.Tag[];
-  buildPageURL: ProjectSearchUrlBuilder;
-  allTags: BestOfJS.Tag[];
+  tags: TagSummary[];
+  buildPageURL: TrendsProjectSearchUrlBuilder;
   textQuery?: string;
 }) {
   return (
@@ -276,7 +282,7 @@ function CurrentTags({
       })}
       {textQuery && (
         <NextLink
-          href={buildPageURL((state: ProjectSearchState) => ({
+          href={buildPageURL((state: TrendsProjectSearchState) => ({
             ...state,
             page: 1,
             query: "",
@@ -292,28 +298,28 @@ function CurrentTags({
 }
 
 async function fetchPageData(
-  searchState: ProjectSearchState,
+  searchState: TrendsProjectSearchState,
 ): Promise<ProjectsPageData> {
-  const { tags, sort, page, limit, query } = searchState;
-  const sortOption = getSortOptionByKey(sort);
+  "use cache";
+  cacheLife("hours");
+  cacheTag("projects");
 
-  const { projects, selectedTags, relevantTags, total, lastUpdateDate } =
-    await api.projects.findProjects({
-      criteria: tags.length > 0 ? { tags: { $all: tags } } : {},
-      query,
-      sort: sortOption.sort,
-      skip: limit * (page - 1),
-      limit,
-    });
+  const { tags: tagCodes, sort, page, limit, query } = searchState;
 
-  const { tags: allTags } = await api.tags.findTags({});
+  const [{ projects: rows, total }, allTags, relevantTags] = await Promise.all([
+    findProjectsWithTrends({ db, limit, page, query, sort, tagCodes }),
+    findTags(),
+    findRelevantTags({ db, tagCodes, query }),
+  ]);
+
+  const tagsByCode = buildTagsByCode(allTags);
+  const projects = rows.map((row) => toTrendsProject(row, tagsByCode));
+  const selectedTags = allTags.filter((tag) => tagCodes.includes(tag.code));
 
   return {
     projects,
     total,
     selectedTags,
     relevantTags,
-    allTags,
-    lastUpdateDate,
   };
 }

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -20,6 +20,7 @@ import { badgeVariants } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { formatNumber } from "@/helpers/numbers";
+import { addCacheBustingParam, getStartOfUtcDay } from "@/helpers/url";
 import { cn } from "@/lib/utils";
 
 import { ProjectListLoading } from "./loading-state";
@@ -53,12 +54,14 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const description = getPageDescription(data, searchState);
 
   const queryString = searchStateParser.stringify(searchState);
+  const imageSearchParams = new URLSearchParams(queryString);
+  addCacheBustingParam(imageSearchParams, getStartOfUtcDay());
 
   return {
     title,
     description,
     openGraph: {
-      images: [`api/og/projects/?${queryString}`],
+      images: [`api/og/projects/?${imageSearchParams.toString()}`],
       url: `${APP_CANONICAL_URL}/projects/?${queryString}`,
       title: `${title} • ${APP_DISPLAY_NAME}`,
       description,

--- a/apps/web/src/app/projects/project-adapter.ts
+++ b/apps/web/src/app/projects/project-adapter.ts
@@ -23,10 +23,11 @@ export function toTrendsProject(
     slug: row.slug,
     name: row.name,
     description: row.description,
-    // Best-of-JS row creation date stands in for both: the new schema
-    // doesn't separately track "GitHub repo created" vs "added to the site".
+    // `added_at` = Best of JS addition date (`projects.created_at`);
+    // `created_at` = GitHub repo creation date (`repos.created_at`), matching
+    // the pre-migration static API and the "Created" sort key.
     added_at: row.createdAt.toISOString(),
-    created_at: row.createdAt.toISOString(),
+    created_at: row.repo.created_at.toISOString(),
     full_name: row.repo.full_name,
     owner_id: row.repo.owner_id,
     pushed_at: row.repo.last_commit?.toISOString() ?? "",

--- a/apps/web/src/app/projects/project-adapter.ts
+++ b/apps/web/src/app/projects/project-adapter.ts
@@ -10,6 +10,11 @@ export type TrendsProject = BestOfJS.Project & {
   activityScore: number | null;
 };
 
+/** Matches the pre-migration static API's `formatDate()` (`YYYY-MM-DD`). */
+function formatDateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
 /**
  * Adapts a `findProjectsWithTrends()` row (nested `repo.*`, tag codes as plain
  * strings) into the flat `BestOfJS.Project` shape the existing list/table/tag
@@ -26,11 +31,13 @@ export function toTrendsProject(
     // `added_at` = Best of JS addition date (`projects.created_at`);
     // `created_at` = GitHub repo creation date (`repos.created_at`), matching
     // the pre-migration static API and the "Created" sort key.
-    added_at: row.createdAt.toISOString(),
-    created_at: row.repo.created_at.toISOString(),
+    // Both are serialized as `YYYY-MM-DD` to preserve shape parity with the
+    // static JSON (`build-static-api.task.ts`'s `formatDate()`).
+    added_at: formatDateOnly(row.createdAt),
+    created_at: formatDateOnly(row.repo.created_at),
     full_name: row.repo.full_name,
     owner_id: row.repo.owner_id,
-    pushed_at: row.repo.last_commit?.toISOString() ?? "",
+    pushed_at: row.repo.last_commit ? formatDateOnly(row.repo.last_commit) : "",
     contributor_count: row.repo.contributor_count ?? 0,
     stars: row.stars,
     // LEFT JOIN repo_trends: null for deprecated repos (no daily tracking);

--- a/apps/web/src/app/projects/project-adapter.ts
+++ b/apps/web/src/app/projects/project-adapter.ts
@@ -1,0 +1,79 @@
+import type { ProjectWithTrends } from "@repo/db/projects";
+
+/**
+ * `BestOfJS.Project` shape plus the two trends-only scores (`popularityScore`,
+ * `activityScore`) that don't exist on the shared static-JSON type — kept as a
+ * local intersection rather than widening `BestOfJS.Project` for every consumer.
+ */
+export type TrendsProject = BestOfJS.Project & {
+  popularityScore: number | null;
+  activityScore: number | null;
+};
+
+/**
+ * Adapts a `findProjectsWithTrends()` row (nested `repo.*`, tag codes as plain
+ * strings) into the flat `BestOfJS.Project` shape the existing list/table/tag
+ * components already render, so those components don't need to change.
+ */
+export function toTrendsProject(
+  row: ProjectWithTrends,
+  tagsByCode: Map<string, BestOfJS.Tag>,
+): TrendsProject {
+  return {
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    // Best-of-JS row creation date stands in for both: the new schema
+    // doesn't separately track "GitHub repo created" vs "added to the site".
+    added_at: row.createdAt.toISOString(),
+    created_at: row.createdAt.toISOString(),
+    full_name: row.repo.full_name,
+    owner_id: row.repo.owner_id,
+    pushed_at: row.repo.last_commit?.toISOString() ?? "",
+    contributor_count: row.repo.contributor_count ?? 0,
+    stars: row.stars,
+    // LEFT JOIN repo_trends: null for deprecated repos (no daily tracking);
+    // individual deltas can also be null before a repo's first full window.
+    trends: row.trends
+      ? {
+          daily: row.trends.daily ?? undefined,
+          weekly: row.trends.weekly ?? undefined,
+          monthly: row.trends.monthly ?? undefined,
+          quarterly: row.trends.quarterly ?? undefined,
+          yearly: row.trends.yearly ?? undefined,
+        }
+      : {},
+    npm: row.packageName ?? "",
+    downloads: row.monthlyDownloads ?? 0,
+    logo: row.logo ?? "",
+    url: row.url ?? "",
+    status: row.status,
+    tags: row.tags
+      .map((code) => tagsByCode.get(code))
+      .filter((tag): tag is BestOfJS.Tag => Boolean(tag)),
+    popularityScore: row.popularityScore,
+    activityScore: row.activityScore,
+  };
+}
+
+/** Builds the `code -> Tag` lookup `toTrendsProject()` needs, from `findTags()`'s result. */
+export function buildTagsByCode(
+  allTags: readonly {
+    code: string;
+    name: string;
+    description: string | null;
+    count: number;
+  }[],
+): Map<string, BestOfJS.Tag> {
+  return new Map(
+    allTags.map((tag) => [
+      tag.code,
+      {
+        code: tag.code,
+        name: tag.name,
+        description: tag.description,
+        counter: tag.count,
+      },
+    ]),
+  );
+}

--- a/apps/web/src/app/projects/trends-project-search-state.ts
+++ b/apps/web/src/app/projects/trends-project-search-state.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+import { trendsSortKeySchema } from "@repo/db/shared-schemas";
+
+import {
+  limitSchema,
+  type PageSearchStateUpdater,
+  type PageSearchUrlBuilder,
+  paginationSchema,
+  SearchStateParser,
+} from "@/lib/page-search-state";
+
+export const trendsProjectSearchStateSchema = paginationSchema.extend({
+  tags: z
+    .preprocess(makeArray, z.array(z.string())) // accept string or array and convert to array
+    .default([]),
+  query: z.string().optional(),
+  sort: trendsSortKeySchema.catch("most-stars").default("most-stars"),
+});
+
+export type TrendsProjectSearchState = z.infer<
+  typeof trendsProjectSearchStateSchema
+>;
+
+export type TrendsProjectSearchUpdater =
+  PageSearchStateUpdater<TrendsProjectSearchState>;
+
+export type TrendsProjectSearchUrlBuilder =
+  PageSearchUrlBuilder<TrendsProjectSearchState>;
+
+export class TrendsProjectSearchStateParser extends SearchStateParser<
+  typeof trendsProjectSearchStateSchema
+> {
+  path = "/projects";
+
+  constructor(options: Partial<TrendsProjectSearchState> = {}) {
+    const { limit = 30 } = options;
+
+    const extendedSchema = trendsProjectSearchStateSchema.extend({
+      limit: limitSchema.default(limit),
+    });
+
+    super(extendedSchema);
+  }
+}
+
+function makeArray(input: unknown) {
+  return typeof input === "string" ? [input] : input;
+}

--- a/apps/web/src/components/project-list/project-table.tsx
+++ b/apps/web/src/components/project-list/project-table.tsx
@@ -184,6 +184,10 @@ export const ProjectScore = ({
   }
 
   if (sort === "most-active") {
+    // No `last_commit` (nullable, e.g. GraphQL commit-history lookup
+    // skipped/failed) → same "fully inactive" state `computeActivityScore`
+    // treats as 0, so nothing to show rather than "Invalid Date".
+    if (!project.pushed_at) return null;
     return (
       <Suspense fallback="...">
         <FromNow date={project.pushed_at} />

--- a/apps/web/src/components/project-list/project-table.tsx
+++ b/apps/web/src/components/project-list/project-table.tsx
@@ -137,12 +137,14 @@ function ProjectTableRow<T extends TagFilterState = TagFilterState>({
 
       {showDetails && (
         <Cell className="hidden w-[180px] space-y-2 p-4 text-sm md:table-cell">
-          <div>
-            Pushed{" "}
-            <Suspense fallback="...">
-              <FromNow date={project.pushed_at} />
-            </Suspense>
-          </div>
+          {project.pushed_at ? (
+            <div>
+              Pushed{" "}
+              <Suspense fallback="...">
+                <FromNow date={project.pushed_at} />
+              </Suspense>
+            </div>
+          ) : null}
           {project.contributor_count > 0 && (
             <div>
               {formatNumber(project.contributor_count, "compact")} contributors

--- a/apps/web/src/components/project-list/project-table.tsx
+++ b/apps/web/src/components/project-list/project-table.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 import NextLink from "next/link";
 
-import type { ProjectSearchUrlBuilder } from "@/app/projects/project-search-state";
 import {
   DownloadCount,
   GitHubIcon,
@@ -16,17 +15,28 @@ import { ProjectTagGroup } from "@/components/tags/project-tag";
 import { buttonVariants } from "@/components/ui/button";
 import { linkVariants } from "@/components/ui/link";
 import { formatNumber } from "@/helpers/numbers";
+import type {
+  PageSearchUrlBuilder,
+  PaginationProps,
+} from "@/lib/page-search-state";
 import { cn } from "@/lib/utils";
 
-type Props = {
+/** Shared shape both the old (static-JSON) and new (DB-trends) search states satisfy. */
+export type TagFilterState = PaginationProps & { tags: string[] };
+
+type Props<T extends TagFilterState = TagFilterState> = {
   projects: BestOfJS.Project[];
-  buildPageURL?: ProjectSearchUrlBuilder;
+  buildPageURL?: PageSearchUrlBuilder<T>;
   footer?: React.ReactNode;
   metricsCell?: (project: BestOfJS.Project) => React.ReactNode;
   showDetails?: boolean;
 };
 
-export const ProjectTable = ({ projects, footer, ...otherProps }: Props) => {
+export function ProjectTable<T extends TagFilterState = TagFilterState>({
+  projects,
+  footer,
+  ...otherProps
+}: Props<T>) {
   return (
     <table className="w-full">
       <tbody className="[&_tr:last-child]:border-0">
@@ -52,17 +62,20 @@ export const ProjectTable = ({ projects, footer, ...otherProps }: Props) => {
       )}
     </table>
   );
-};
+}
 
-type RowProps = Pick<Props, "buildPageURL" | "metricsCell" | "showDetails"> & {
+type RowProps<T extends TagFilterState = TagFilterState> = Pick<
+  Props<T>,
+  "buildPageURL" | "metricsCell" | "showDetails"
+> & {
   project: BestOfJS.Project;
 };
-const ProjectTableRow = ({
+function ProjectTableRow<T extends TagFilterState = TagFilterState>({
   project,
   buildPageURL,
   showDetails = true,
   metricsCell,
-}: RowProps) => {
+}: RowProps<T>) {
   const path = `/projects/${project.slug}`;
 
   return (
@@ -151,7 +164,7 @@ const ProjectTableRow = ({
       )}
     </tr>
   );
-};
+}
 
 export const ProjectScore = ({
   project,
@@ -160,8 +173,26 @@ export const ProjectScore = ({
   project: BestOfJS.Project;
   sort: string;
 }) => {
+  if (sort === "trending") {
+    // No single raw signal maps 1:1 to the blended popularity score; show the
+    // freshest star-delta window available (same fallback chain the score
+    // itself uses for young repos without a yearly delta yet).
+    const value =
+      project.trends.yearly ?? project.trends.monthly ?? project.trends.daily;
+    if (value === undefined) return null;
+    return <StarDelta average={false} value={value} />;
+  }
+
+  if (sort === "most-active") {
+    return (
+      <Suspense fallback="...">
+        <FromNow date={project.pushed_at} />
+      </Suspense>
+    );
+  }
+
   const showDelta = ["daily", "weekly", "monthly", "yearly"].includes(sort);
-  const showDownloads = sort === "monthly-downloads";
+  const showDownloads = sort === "monthly-downloads" || sort === "most-used";
 
   if (showDelta) {
     const value = getDeltaByDay(sort)(project);

--- a/apps/web/src/components/project-list/project-table.tsx
+++ b/apps/web/src/components/project-list/project-table.tsx
@@ -192,7 +192,7 @@ export const ProjectScore = ({
   }
 
   const showDelta = ["daily", "weekly", "monthly", "yearly"].includes(sort);
-  const showDownloads = sort === "monthly-downloads" || sort === "most-used";
+  const showDownloads = sort === "monthly-downloads";
 
   if (showDelta) {
     const value = getDeltaByDay(sort)(project);

--- a/apps/web/src/components/project-list/trends-project-paginated-list.tsx
+++ b/apps/web/src/components/project-list/trends-project-paginated-list.tsx
@@ -1,0 +1,77 @@
+import type {
+  TrendsProjectSearchState,
+  TrendsProjectSearchUrlBuilder,
+} from "@/app/projects/trends-project-search-state";
+import { Card, CardHeader } from "@/components/ui/card";
+
+import {
+  BottomPaginationControls,
+  TopPaginationControls,
+} from "../core/pagination/pagination-controls";
+import { computePaginationState } from "../core/pagination/pagination-state";
+import { ProjectScore, ProjectTable } from "./project-table";
+import { TrendsProjectSortOrderPicker } from "./trends-sort-order-picker";
+
+type Props = {
+  projects: BestOfJS.Project[];
+  searchState: TrendsProjectSearchState;
+  buildPageURL: TrendsProjectSearchUrlBuilder;
+  total: number;
+};
+export const TrendsProjectPaginatedList = ({
+  projects,
+  buildPageURL,
+  searchState,
+  total,
+}: Props) => {
+  const { page, limit, sort } = searchState;
+  const showPagination = total > limit;
+  const showSortOptions = total > 1;
+  const paginationState = computePaginationState({ page, limit, total });
+
+  if (total === 0) {
+    return (
+      <Card className="flex items-center justify-center py-8">
+        No projects found
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        {(showSortOptions || showPagination) && (
+          <div className="flex w-full flex-col justify-between gap-4 md:flex-row">
+            {showSortOptions && (
+              <TrendsProjectSortOrderPicker
+                value={sort}
+                buildPageURL={buildPageURL}
+              />
+            )}
+            {showPagination && (
+              <TopPaginationControls
+                paginationState={paginationState}
+                buildPageURL={buildPageURL}
+              />
+            )}
+          </div>
+        )}
+      </CardHeader>
+      <ProjectTable
+        projects={projects}
+        buildPageURL={buildPageURL}
+        metricsCell={(project) => (
+          <ProjectScore project={project} sort={sort} />
+        )}
+        footer={
+          <div className="flex justify-end">
+            <BottomPaginationControls
+              paginationState={paginationState}
+              buildPageURL={buildPageURL}
+            />
+          </div>
+        }
+      />
+    </Card>
+  );
+};

--- a/apps/web/src/components/project-list/trends-sort-order-options.ts
+++ b/apps/web/src/components/project-list/trends-sort-order-options.ts
@@ -46,9 +46,20 @@ export const trendsSortOrderOptions: TrendsSortOption[] = [
     shortLabel: "Active",
   },
   {
-    key: "most-used",
-    label: "Most used (NPM downloads)",
-    shortLabel: "Downloads",
+    key: "last-commit",
+    label: "By date of the latest commit",
+  },
+  {
+    key: "contributors",
+    label: "By number of contributors",
+  },
+  {
+    key: "monthly-downloads",
+    label: "By downloads the last 30 days",
+  },
+  {
+    key: "created",
+    label: "By date of creation (Oldest first)",
   },
   {
     key: "newest",

--- a/apps/web/src/components/project-list/trends-sort-order-options.ts
+++ b/apps/web/src/components/project-list/trends-sort-order-options.ts
@@ -1,0 +1,69 @@
+import { keyBy } from "es-toolkit";
+
+import type { TrendsSortKey } from "@repo/db/shared-schemas";
+
+export type TrendsSortOption = {
+  key: TrendsSortKey;
+  label: string;
+  shortLabel?: string;
+};
+
+// Sorting itself happens in the DB query (`findProjectsWithTrends()`); this
+// file only carries display metadata for the sort dropdown.
+export const trendsSortOrderOptions: TrendsSortOption[] = [
+  {
+    key: "most-stars",
+    label: "By total number of stars",
+  },
+  {
+    key: "daily",
+    label: "By stars added yesterday",
+    shortLabel: "Today",
+  },
+  {
+    key: "weekly",
+    label: "By stars added the last 7 days",
+    shortLabel: "Last 7 days",
+  },
+  {
+    key: "monthly",
+    label: "By stars added the last 30 days",
+    shortLabel: "Last 30 days",
+  },
+  {
+    key: "yearly",
+    label: "By stars added the last 12 months",
+    shortLabel: "Last 12 months",
+  },
+  {
+    key: "trending",
+    label: "Trending (star momentum)",
+    shortLabel: "Trending",
+  },
+  {
+    key: "most-active",
+    label: "Most active (maintenance)",
+    shortLabel: "Active",
+  },
+  {
+    key: "most-used",
+    label: "Most used (NPM downloads)",
+    shortLabel: "Downloads",
+  },
+  {
+    key: "newest",
+    label: "Newest on Best of JS",
+    shortLabel: "Newest",
+  },
+];
+
+export const trendsSortOrderOptionsByKey = keyBy(
+  trendsSortOrderOptions,
+  (item) => item.key,
+) as Record<TrendsSortKey, TrendsSortOption>;
+
+export function getTrendsSortOptionByKey(sortKey: string): TrendsSortOption {
+  const defaultOption = trendsSortOrderOptionsByKey["most-stars"];
+  if (!sortKey) return defaultOption;
+  return trendsSortOrderOptionsByKey[sortKey as TrendsSortKey] || defaultOption;
+}

--- a/apps/web/src/components/project-list/trends-sort-order-picker.tsx
+++ b/apps/web/src/components/project-list/trends-sort-order-picker.tsx
@@ -19,9 +19,10 @@ const sortOptionGroups: TrendsSortKey[][] = [
   ["most-stars"],
   ["daily", "weekly", "monthly", "yearly"],
   ["trending"],
+  ["monthly-downloads"],
+  ["last-commit", "contributors"],
   ["most-active"],
-  ["most-used"],
-  ["newest"],
+  ["created", "newest"],
 ];
 
 type Props = {

--- a/apps/web/src/components/project-list/trends-sort-order-picker.tsx
+++ b/apps/web/src/components/project-list/trends-sort-order-picker.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+import type { TrendsSortKey } from "@repo/db/shared-schemas";
+
+import type { TrendsProjectSearchUrlBuilder } from "@/app/projects/trends-project-search-state";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import { ChevronDownIcon } from "../core";
+import { trendsSortOrderOptionsByKey } from "./trends-sort-order-options";
+
+const sortOptionGroups: TrendsSortKey[][] = [
+  ["most-stars"],
+  ["daily", "weekly", "monthly", "yearly"],
+  ["trending"],
+  ["most-active"],
+  ["most-used"],
+  ["newest"],
+];
+
+type Props = {
+  value: TrendsSortKey;
+  buildPageURL: TrendsProjectSearchUrlBuilder;
+};
+export function TrendsProjectSortOrderPicker({ value, buildPageURL }: Props) {
+  const currentOption = trendsSortOrderOptionsByKey[value];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">
+          Sort: {currentOption?.label || ""}
+          <ChevronDownIcon className="size-6" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-[300px] divide-y">
+        {sortOptionGroups.map((group, index) => {
+          return (
+            <DropdownMenuGroup key={index} className="py-2">
+              {group.map((key) => {
+                const item = trendsSortOrderOptionsByKey[key];
+                const url = buildPageURL((state) => ({
+                  ...state,
+                  sort: item.key,
+                  page: 1,
+                }));
+
+                return (
+                  <DropdownMenuItem key={key} asChild>
+                    <Link href={url}>{item.label}</Link>
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuGroup>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/tags/project-tag.tsx
+++ b/apps/web/src/components/tags/project-tag.tsx
@@ -1,18 +1,22 @@
 import NextLink from "next/link";
 
-import type { ProjectSearchUrlBuilder } from "@/app/projects/project-search-state";
+import type { TagFilterState } from "@/components/project-list/project-table";
 import { badgeVariants } from "@/components/ui/badge";
+import type { PageSearchUrlBuilder } from "@/lib/page-search-state";
 import { cn } from "@/lib/utils";
 
 import { ProjectTagHoverCard } from "./project-tag-hover-card";
 
-type Props = {
+type Props<T extends TagFilterState = TagFilterState> = {
   tags: BestOfJS.RawTag[];
   appendTag?: boolean;
-  buildPageURL?: ProjectSearchUrlBuilder;
+  buildPageURL?: PageSearchUrlBuilder<T>;
 };
 
-export const ProjectTagGroup = ({ tags, ...otherProps }: Props) => {
+export function ProjectTagGroup<T extends TagFilterState = TagFilterState>({
+  tags,
+  ...otherProps
+}: Props<T>) {
   return (
     <div className="-m-1 flex flex-wrap">
       {tags.map((tag) => (
@@ -22,19 +26,19 @@ export const ProjectTagGroup = ({ tags, ...otherProps }: Props) => {
       ))}
     </div>
   );
-};
+}
 
-export const ProjectTag = ({
+export function ProjectTag<T extends TagFilterState = TagFilterState>({
   tag,
   buildPageURL,
   appendTag,
   className,
 }: {
   tag: BestOfJS.RawTag;
-  buildPageURL?: Props["buildPageURL"];
+  buildPageURL?: Props<T>["buildPageURL"];
   appendTag?: boolean;
   className?: string;
-}) => {
+}) {
   const url = buildPageURL
     ? buildPageURL(
         (state) => ({
@@ -60,4 +64,4 @@ export const ProjectTag = ({
       </NextLink>
     </ProjectTagHoverCard>
   );
-};
+}

--- a/apps/web/src/helpers/url.ts
+++ b/apps/web/src/helpers/url.ts
@@ -16,3 +16,18 @@ export function addCacheBustingParam(
   const dateParam = date.toISOString().slice(0, 16).replace(":", "-"); // 2020-01-01T00:00 => 2020-01-01T00-00
   searchParams.set("t", dateParam);
 }
+
+/**
+ * Start of the current UTC day, for `addCacheBustingParam()` on DB-backed
+ * pages: their data has no single "last build" timestamp like the old static
+ * JSON did, but it's refreshed at most once a day (the `daily-update-trends`
+ * pipeline), so truncating to the day is the coarsest value that still busts
+ * external caches (Twitter/Slack/Facebook link previews) at the right cadence
+ * without changing the URL more often than the data actually changes.
+ */
+export function getStartOfUtcDay(): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+}

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -57,7 +57,7 @@ Calibrated so **100 requires 2 billion downloads/month** — a ceiling only the 
 
 The original slope (100 at 10M/month) saturated hundreds of popular packages at 100.
 
-**Not a sort key:** the **Most used** sort orders by raw `monthly_downloads`. Any log-scale score buckets projects into ties (the listing then degrades to alphabetical order); raw counts give an exact order. The score only feeds the relevance blend, where clamping is harmless.
+**Not a sort key:** the **Monthly downloads** sort orders by raw `monthly_downloads`. Any log-scale score buckets projects into ties (the listing then degrades to alphabetical order); raw counts give an exact order. The score only feeds the relevance blend, where clamping is harmless.
 
 ## `relevance_score` — the quality floor
 
@@ -83,16 +83,23 @@ Because deprecated repos have no `repo_trends` row, the listing query (`findProj
 | Monthly | `repo_trends.monthly` |
 | Yearly | `repo_trends.yearly` |
 | Trending | `repo_trends.popularity_score` |
+| Monthly downloads | `project_trends.monthly_downloads` |
+| Last commit | `repos.last_commit` |
+| Contributors | `repos.contributor_count` |
 | Most active | `repo_trends.activity_score` |
-| Most used | `project_trends.monthly_downloads` |
+| Created (oldest first) | `repos.created_at` |
 | Newest | `projects.created_at` |
 
-All descending, `NULLS LAST`, tie-broken by `slug ASC` for deterministic pagination. Weekly/Monthly/
-Yearly restore the pre-migration per-window star-delta sorts alongside Trending's blended score;
-their metric column shows the plain per-day average for that window (`getDeltaByDay()` + `StarDelta`
-on the web app), while Trending's column shows the freshest raw delta available (yearly, falling
-back to monthly then daily) rather than the score itself, since sorting by a metric should display
-that metric.
+All descending except **Created**, which is ascending (oldest GitHub repo first — the one
+pre-migration sort that inverts direction); `NULLS LAST`, tie-broken by `slug ASC` for deterministic
+pagination. Weekly/Monthly/Yearly restore the pre-migration per-window star-delta sorts alongside
+Trending's blended score; their metric column shows the plain per-day average for that window
+(`getDeltaByDay()` + `StarDelta` on the web app), while Trending's column shows the freshest raw
+delta available (yearly, falling back to monthly then daily) rather than the score itself, since
+sorting by a metric should display that metric. **Last commit** and **Contributors** are raw signals
+kept alongside — not instead of — the blended **Most active** score; they sort by `repos.last_commit`
+/`repos.contributor_count` directly with no metric-column treatment (same as pre-migration, where
+these two, like most other sorts, just displayed the star count).
 
 ## How to tune
 
@@ -102,6 +109,14 @@ that metric.
 
 ## Decision log
 
+- **2026-07-20** — Restored the remaining pre-migration sort keys dropped by the initial DB
+  migration: **Monthly downloads** (renamed back from `"most-used"` — same underlying data, just the
+  literal old key, matching the `daily` rename below), and **Last commit** / **Contributors** /
+  **Created** as their own standalone sorts (`repos.last_commit`, `repos.contributor_count`,
+  `repos.created_at`, all already joined in `findProjectsWithTrends()`). Last commit/Contributors sit
+  alongside — not instead of — the blended **Most active** score, which was a deliberate
+  consolidation the PRD made; that design intent is preserved, these are additive. Created is
+  ascending (oldest first), the one sort that inverts direction.
 - **2026-07-20** — Renamed the `"hot-today"` sort key to `"daily"` for consistency with
   `weekly`/`monthly`/`yearly` (all four now use their literal pre-migration key names). Caught
   because `/projects?sort=daily` — a valid URL on the pre-migration page — silently fell back to the

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -22,7 +22,7 @@ score = sign(raw) * log10(1 + |raw| / 10) * 30
 
 Range ~ −100 to +100 (raw +1000/year ≈ 60, +10k/year ≈ 90). Sort key for **Trending**.
 
-**Why daily and weekly are excluded:** GitHub stars have mysterious one-day spikes and drops — spam-account purges, viral bursts. The original formula (`yearly + monthly*6 + daily*180`) let a single day outweigh a year: TanStack Query, at +4.1K stars/year, scored **−46.8** because of one −30 purge day (`−30 × 180 = −5400` vs `4100 + 984` of genuine growth). Monthly and yearly windows dilute this noise. The daily signal keeps its own dedicated sort ("Hot today").
+**Why daily and weekly are excluded:** GitHub stars have mysterious one-day spikes and drops — spam-account purges, viral bursts. The original formula (`yearly + monthly*6 + daily*180`) let a single day outweigh a year: TanStack Query, at +4.1K stars/year, scored **−46.8** because of one −30 purge day (`−30 × 180 = −5400` vs `4100 + 984` of genuine growth). Monthly and yearly windows dilute this noise. The daily signal keeps its own dedicated sort ("Daily").
 
 **Young-repo fallback:** repos tracked for less than a month have no monthly delta yet. The monthly momentum is then extrapolated from the freshest window available — `weekly*4`, then `daily*30` — so a hot new project still surfaces in "Trending" during its first weeks. Once a real monthly delta exists, daily/weekly are ignored entirely.
 
@@ -77,14 +77,22 @@ Because deprecated repos have no `repo_trends` row, the listing query (`findProj
 
 | UI label | ORDER BY |
 |---|---|
+| Most stars (default) | `COALESCE(repo_trends.stars, repos.stars)` |
+| Daily | `repo_trends.daily` |
+| Weekly | `repo_trends.weekly` |
+| Monthly | `repo_trends.monthly` |
+| Yearly | `repo_trends.yearly` |
 | Trending | `repo_trends.popularity_score` |
-| Hot today | `repo_trends.daily` |
-| Most stars | `COALESCE(repo_trends.stars, repos.stars)` |
 | Most active | `repo_trends.activity_score` |
 | Most used | `project_trends.monthly_downloads` |
 | Newest | `projects.created_at` |
 
-All descending, `NULLS LAST`, tie-broken by `slug ASC` for deterministic pagination.
+All descending, `NULLS LAST`, tie-broken by `slug ASC` for deterministic pagination. Weekly/Monthly/
+Yearly restore the pre-migration per-window star-delta sorts alongside Trending's blended score;
+their metric column shows the plain per-day average for that window (`getDeltaByDay()` + `StarDelta`
+on the web app), while Trending's column shows the freshest raw delta available (yearly, falling
+back to monthly then daily) rather than the score itself, since sorting by a metric should display
+that metric.
 
 ## How to tune
 
@@ -94,5 +102,16 @@ All descending, `NULLS LAST`, tie-broken by `slug ASC` for deterministic paginat
 
 ## Decision log
 
+- **2026-07-20** — Renamed the `"hot-today"` sort key to `"daily"` for consistency with
+  `weekly`/`monthly`/`yearly` (all four now use their literal pre-migration key names). Caught
+  because `/projects?sort=daily` — a valid URL on the pre-migration page — silently fell back to the
+  default instead of sorting by the daily delta, since only this one key had been renamed.
+- **2026-07-20** — Restored **Weekly**/**Monthly**/**Yearly** as their own sort options (dropped in
+  the initial DB migration in favor of the blended Trending score alone) after user feedback that it
+  was a real capability loss versus the pre-migration listing. Default sort changed from Trending to
+  **Most stars** (Trending as a default was judged too obscure). Trending's and Most active's metric
+  columns changed from showing the raw computed score (e.g. "98.3", "84") to showing a recognizable
+  signal instead — Trending shows the freshest star-delta window available, Most active shows "last
+  commit N days ago" — since sorting by a metric should display that metric.
 - **2026-07-18** — `usage_score` recalibrated from "100 at 10M downloads/month" to "100 at 2B/month" (score saturation caused alphabetical ties); **Most used** sort switched from `usage_score` to raw `monthly_downloads`; deprecated malus adjusted −20 → −17 to preserve the ~10M visibility threshold; `popularity_score` blend changed from `yearly + monthly*6 + daily*180` to `yearly + monthly*6` with a weekly/daily extrapolation fallback for repos tracked < 1 month (one-day GitHub star purges were dominating the score — the TanStack Query case).
 - **2026-05** (tasks 1–2, issues #422/#423) — initial scoring system per the [PRD](../prd/replace-static-api-with-db.md).

--- a/packages/db/src/projects/find-with-trends.ts
+++ b/packages/db/src/projects/find-with-trends.ts
@@ -16,7 +16,10 @@ const starsExpression = sql<number>`COALESCE(${repoTrends.stars}, ${repos.stars}
 
 const sortExpressionByKey: Record<TrendsSortKey, SQL> = {
   trending: sql`${repoTrends.popularityScore}`,
-  "hot-today": sql`${repoTrends.daily}`,
+  daily: sql`${repoTrends.daily}`,
+  weekly: sql`${repoTrends.weekly}`,
+  monthly: sql`${repoTrends.monthly}`,
+  yearly: sql`${repoTrends.yearly}`,
   "most-stars": starsExpression,
   "most-active": sql`${repoTrends.activityScore}`,
   // raw downloads, not `usage_score`: the log-scale score buckets projects
@@ -58,7 +61,7 @@ export async function findProjectsWithTrends({
   page = 1,
   query,
   relevanceFloor = true,
-  sort = "trending",
+  sort = "most-stars",
   tagCodes,
 }: FindProjectsWithTrendsOptions) {
   const offset = (page - 1) * limit;

--- a/packages/db/src/projects/find-with-trends.ts
+++ b/packages/db/src/projects/find-with-trends.ts
@@ -22,9 +22,13 @@ const sortExpressionByKey: Record<TrendsSortKey, SQL> = {
   yearly: sql`${repoTrends.yearly}`,
   "most-stars": starsExpression,
   "most-active": sql`${repoTrends.activityScore}`,
+  "last-commit": sql`${repos.last_commit}`,
+  contributors: sql`${repos.contributor_count}`,
   // raw downloads, not `usage_score`: the log-scale score buckets projects
   // together (ties), raw counts give an exact order
-  "most-used": sql`${projectTrends.monthlyDownloads}`,
+  "monthly-downloads": sql`${projectTrends.monthlyDownloads}`,
+  // ascending: oldest GitHub repo first (see `getOrderByQuery`)
+  created: sql`${repos.created_at}`,
   newest: sql`${projects.createdAt}`,
 };
 
@@ -92,6 +96,7 @@ export async function findProjectsWithTrends({
         archived: repos.archived,
         last_commit: repos.last_commit,
         contributor_count: repos.contributor_count,
+        created_at: repos.created_at,
       },
       stars: starsExpression,
       trends: {
@@ -138,10 +143,16 @@ export async function findProjectsWithTrends({
 
 function getOrderByQuery(sort: TrendsSortKey) {
   const expression = sortExpressionByKey[sort];
+  const primary =
+    // "created" is the one sort that means "oldest first"; `repos.created_at`
+    // is NOT NULL so no nulls-handling is needed. Every other sort is
+    // descending, with `NULLS LAST` keeping projects without a `repo_trends`
+    // row (deprecated) at the bottom instead of the top.
+    sort === "created"
+      ? sql`${expression} asc`
+      : sql`${expression} desc nulls last`;
   return [
-    // Every sort option is descending; `NULLS LAST` keeps projects without
-    // a `repo_trends` row (deprecated) at the bottom instead of the top.
-    sql`${expression} desc nulls last`,
+    primary,
     // Tiebreaker to make pagination deterministic
     sql`${projects.slug} asc`,
   ];

--- a/packages/db/src/shared-schemas.ts
+++ b/packages/db/src/shared-schemas.ts
@@ -29,7 +29,10 @@ export const trendsSortKeySchema = z.enum([
   "yearly",
   "most-stars",
   "most-active",
-  "most-used",
+  "last-commit",
+  "contributors",
+  "monthly-downloads",
+  "created",
   "newest",
 ]);
 

--- a/packages/db/src/shared-schemas.ts
+++ b/packages/db/src/shared-schemas.ts
@@ -23,7 +23,10 @@ export type ProjectsSortableColumnName = z.infer<typeof columnIdsSchema>;
 /** Sort options for the trends-backed queries used by the public web app */
 export const trendsSortKeySchema = z.enum([
   "trending",
-  "hot-today",
+  "daily",
+  "weekly",
+  "monthly",
+  "yearly",
   "most-stars",
   "most-active",
   "most-used",

--- a/packages/db/src/tags/find-relevant.ts
+++ b/packages/db/src/tags/find-relevant.ts
@@ -1,0 +1,68 @@
+import { and, count, desc, eq, gte, notInArray } from "drizzle-orm";
+
+import type { DB } from "../index";
+import {
+  getWhereClauseSearchByTag,
+  getWhereClauseSearchByText,
+} from "../projects/find";
+import * as schema from "../schema";
+
+const { projects, projectTrends, projectsToTags, repos, tags } = schema;
+
+export interface FindRelevantTagsOptions {
+  db: DB;
+  /** Already-selected tag codes: scope to projects having ALL of them, exclude them from the output */
+  tagCodes?: string[];
+  /** Text search on project name/description and repo owner/name, same scoping as findProjectsWithTrends() */
+  query?: string;
+  /** Quality floor matching findProjectsWithTrends()'s default; disable for the future /search route */
+  relevanceFloor?: boolean;
+  limit?: number;
+}
+
+export interface RelevantTag {
+  code: string;
+  name: string;
+  description: string | null;
+  count: number;
+}
+
+/**
+ * Tags that commonly co-occur with the current `findProjectsWithTrends()` result set,
+ * excluding already-selected tags. Powers the "related tags" row on `/projects`.
+ */
+export async function findRelevantTags({
+  db,
+  tagCodes,
+  query,
+  relevanceFloor = true,
+  limit = 20,
+}: FindRelevantTagsOptions): Promise<RelevantTag[]> {
+  const where = and(
+    relevanceFloor ? gte(projectTrends.relevanceScore, 0) : undefined,
+    query ? getWhereClauseSearchByText(query) : undefined,
+    tagCodes && tagCodes.length > 0
+      ? getWhereClauseSearchByTag(db, tagCodes)
+      : undefined,
+    tagCodes && tagCodes.length > 0
+      ? notInArray(tags.code, tagCodes)
+      : undefined,
+  );
+
+  return db
+    .select({
+      code: tags.code,
+      name: tags.name,
+      description: tags.description,
+      count: count(projectsToTags.projectId),
+    })
+    .from(tags)
+    .innerJoin(projectsToTags, eq(projectsToTags.tagId, tags.id))
+    .innerJoin(projects, eq(projects.id, projectsToTags.projectId))
+    .innerJoin(projectTrends, eq(projectTrends.projectId, projects.id))
+    .innerJoin(repos, eq(projects.repoId, repos.id))
+    .where(where)
+    .groupBy(tags.id)
+    .orderBy(desc(count(projectsToTags.projectId)))
+    .limit(limit);
+}

--- a/packages/db/src/tags/index.ts
+++ b/packages/db/src/tags/index.ts
@@ -1,4 +1,5 @@
 export * from "./create";
 export * from "./find";
+export * from "./find-relevant";
 export * from "./get";
 export * from "./update";


### PR DESCRIPTION
## Goal

Migrate the `/projects` listing page from the static JSON/mingo pipeline to `findProjectsWithTrends()`, the DB-backed query built in #424. Fixes #425 (Task 4/7 of #413).

- Sort options, tag filtering, text search and pagination now run against `repo_trends`/`project_trends` instead of the static API.
- Sort UX was revised after trying it against real data: raw signals (star deltas, last-commit recency) are shown instead of abstract scores, and all pre-migration sort keys (Weekly/Monthly/Yearly, Monthly downloads, Last commit, Contributors, Created) are preserved alongside the new Trending/Most active blended scores.
- The `/api/og/projects` social-preview image route was updated in step with the new sort keys, including cache-busting and relative-date rendering for "Most active".

See `docs/architecture/scoring.md` for the sort-key → column mapping and the decision log entries dated 2026-07-20.

## How to test

- `/projects` — all sort options, tag filters, text search, pagination.
- `/tags` and the homepage trend sections should be unaffected (untouched query paths).
- OG image previews at `/api/og/projects` for a few sort keys, including "Most active" with a repo that has no commits.