### PR TITLE
Task 5/7: Unify full-catalog search into /projects (remove relevance floor)

### DIFF
--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -53,8 +53,9 @@ export function createTaskRunner(tasks: Task<RawFlags | undefined>[]) {
           for (const task of tasks) {
             i++;
             const taskFlags = task.schema?.parse(rawFlags);
+            const flagsText = stringifyFlags(flags, taskFlags);
             logger.box(
-              `Running task ${i}/${tasks.length} "${task.name}" ${stringifyFlags(flags, taskFlags)}`,
+              `Running task ${i}/${tasks.length} "${task.name}"${flagsText ? `\n\n${flagsText}` : ""}`,
             );
             const context = createTaskContext(db);
 
@@ -139,17 +140,22 @@ function stringifyFlags(flags: ParsedFlags, taskFlags?: RawFlags) {
   const { dryRun, limit, logLevel, skip, concurrency, throttleInterval } =
     flags;
 
-  return [
-    `logLevel: ${logLevel}`,
-    limit ? `limit: ${limit}` : "",
-    skip ? `skip: ${skip}` : "",
-    concurrency > 1 ? `concurrency: ${concurrency}` : "",
-    throttleInterval ? `throttleInterval: ${throttleInterval}` : "",
-    dryRun ? "DRY RUN" : "",
-  ]
-    .concat(
-      Object.entries(taskFlags || {}).map(([key, value]) => `${key}: ${value}`),
-    )
-    .filter(Boolean)
-    .join(", ");
+  return (
+    [
+      `logLevel: ${logLevel}`,
+      limit ? `limit: ${limit}` : "",
+      skip ? `skip: ${skip}` : "",
+      concurrency > 1 ? `concurrency: ${concurrency}` : "",
+      throttleInterval ? `throttleInterval: ${throttleInterval}` : "",
+      dryRun ? "DRY RUN" : "",
+    ]
+      .concat(
+        Object.entries(taskFlags || {})
+          .filter(([, value]) => value !== undefined)
+          .map(([key, value]) => `${key}: ${value}`),
+      )
+      .filter(Boolean)
+      // one flag per line so long flag sets don't overflow the box
+      .join("\n")
+  );
 }

--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -145,7 +145,10 @@ function checkRelevanceFloor(
 ) {
   if (fullCatalog) return [];
   return projects
-    .filter((project) => project.relevanceScore < 0)
+    .filter(
+      (project) =>
+        project.relevanceScore !== null && project.relevanceScore < 0,
+    )
     .map(
       (project) =>
         `"${project.slug}" has a negative relevance score (${project.relevanceScore}) but the floor is enabled`,

--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -17,7 +17,8 @@ import { createTask } from "@/task-runner";
  * local or production database. Prints the results of
  * `findProjectsWithTrends()` for the given flags and checks invariants that
  * fixtures-free testing can verify on real data:
- * - relevance floor: no project with `relevance_score < 0` unless `--fullCatalog`
+ * - relevance floor: when the legacy floored view is selected (`--no-fullCatalog`),
+ *   no shown project has `relevance_score < 0`
  * - sort order: values non-increasing, NULLs (missing `repo_trends` row) last
  * - tag filter: every result has ALL the requested tags
  * - the full catalog is never smaller than the floored listing
@@ -45,8 +46,8 @@ export const checkTrendsQueriesTask = createTask({
     fullCatalog: {
       type: Boolean,
       description:
-        "Disable the relevance-score floor, querying the full catalog (`/search` mode)",
-      default: false,
+        "Show the full catalog with the relevance floor disabled — the live site default. Pass --no-fullCatalog to preview the legacy floored listing.",
+      default: true,
     },
     page: {
       type: Number,
@@ -63,7 +64,7 @@ export const checkTrendsQueriesTask = createTask({
     sort: trendsSortKeySchema.optional().default("most-stars"),
     tags: z.string().optional(),
     search: z.string().optional(),
-    fullCatalog: z.boolean().optional().default(false),
+    fullCatalog: z.boolean().optional().default(true),
     page: z.number().optional().default(1),
     limit: z.number().optional().default(0), // shared flag; 0 means "not provided"
     columns: z.string().optional(),

--- a/apps/web/src/app/projects/[slug]/project-header.tsx
+++ b/apps/web/src/app/projects/[slug]/project-header.tsx
@@ -9,7 +9,7 @@ import {
 } from "@repo/db/projects";
 
 import { GitHubIcon, HomeIcon, NpmIcon, ProjectLogo } from "@/components/core";
-import { ProjectTagGroup } from "@/components/tags/project-tag";
+import { ProjectTagGroup } from "@/components/tags/project-tag-group";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { formatUrl } from "@/helpers/url";

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -60,6 +60,9 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   return {
     title,
     description,
+    // Text-search result pages are ephemeral/near-infinite; keep them out of
+    // the index. The bare listing and tag-filtered pages stay indexable.
+    ...(searchState.query ? { robots: { index: false } } : {}),
     openGraph: {
       images: [`api/og/projects/?${imageSearchParams.toString()}`],
       url: `${APP_CANONICAL_URL}/projects/?${queryString}`,

--- a/apps/web/src/components/home/featured-project-list.tsx
+++ b/apps/web/src/components/home/featured-project-list.tsx
@@ -53,6 +53,7 @@ function FeaturedProject({
         )}
         <ProjectTag
           tag={project.tags[0]}
+          url={`/projects?tags=${project.tags[0].code}`}
           className="inline-block max-w-full truncate"
         />
       </div>

--- a/apps/web/src/components/project-list/project-table.tsx
+++ b/apps/web/src/components/project-list/project-table.tsx
@@ -11,7 +11,7 @@ import {
   StarTotal,
 } from "@/components/core";
 import { FromNow } from "@/components/helpers.client";
-import { ProjectTagGroup } from "@/components/tags/project-tag";
+import { ProjectTagGroup } from "@/components/tags/project-tag-group";
 import { buttonVariants } from "@/components/ui/button";
 import { linkVariants } from "@/components/ui/link";
 import { formatNumber } from "@/helpers/numbers";

--- a/apps/web/src/components/tag-list/compact-tag-list.tsx
+++ b/apps/web/src/components/tag-list/compact-tag-list.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Link from "next/link";
 
 import { ProjectTagHoverCard } from "@/components/tags/project-tag-hover-card";

--- a/apps/web/src/components/tags/project-tag-group.tsx
+++ b/apps/web/src/components/tags/project-tag-group.tsx
@@ -1,0 +1,38 @@
+import type { TagFilterState } from "@/components/project-list/project-table";
+import type { PageSearchUrlBuilder } from "@/lib/page-search-state";
+
+import { ProjectTag } from "./project-tag";
+
+type Props<T extends TagFilterState = TagFilterState> = {
+  tags: BestOfJS.RawTag[];
+  appendTag?: boolean;
+  buildPageURL?: PageSearchUrlBuilder<T>;
+};
+
+export function ProjectTagGroup<T extends TagFilterState = TagFilterState>({
+  tags,
+  appendTag,
+  buildPageURL,
+}: Props<T>) {
+  return (
+    <div className="-m-1 flex flex-wrap">
+      {tags.map((tag) => {
+        const url = buildPageURL
+          ? buildPageURL(
+              (state) => ({
+                ...state,
+                tags: appendTag ? [...state.tags, tag.code] : [tag.code],
+                page: 1,
+              }),
+              "/projects",
+            )
+          : `/projects?tags=${tag.code}`;
+        return (
+          <div key={tag.code} className="m-1">
+            <ProjectTag tag={tag} url={url} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/tags/project-tag.tsx
+++ b/apps/web/src/components/tags/project-tag.tsx
@@ -1,56 +1,20 @@
 "use client";
+
 import NextLink from "next/link";
 
-import type { TagFilterState } from "@/components/project-list/project-table";
+import { ProjectTagHoverCard } from "./project-tag-hover-card";
 import { badgeVariants } from "@/components/ui/badge";
-import type { PageSearchUrlBuilder } from "@/lib/page-search-state";
 import { cn } from "@/lib/utils";
 
-import { ProjectTagHoverCard } from "./project-tag-hover-card";
-
-type Props<T extends TagFilterState = TagFilterState> = {
-  tags: BestOfJS.RawTag[];
-  appendTag?: boolean;
-  buildPageURL?: PageSearchUrlBuilder<T>;
-};
-
-export function ProjectTagGroup<T extends TagFilterState = TagFilterState>({
-  tags,
-  ...otherProps
-}: Props<T>) {
-  return (
-    <div className="-m-1 flex flex-wrap">
-      {tags.map((tag) => (
-        <div key={tag.code} className="m-1">
-          <ProjectTag tag={tag} {...otherProps} />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-export function ProjectTag<T extends TagFilterState = TagFilterState>({
+export function ProjectTag({
   tag,
-  buildPageURL,
-  appendTag,
+  url,
   className,
 }: {
   tag: BestOfJS.RawTag;
-  buildPageURL?: Props<T>["buildPageURL"];
-  appendTag?: boolean;
+  url: string;
   className?: string;
 }) {
-  const url = buildPageURL
-    ? buildPageURL(
-        (state) => ({
-          ...state,
-          tags: appendTag ? [...state.tags, tag.code] : [tag.code],
-          page: 1,
-        }),
-        "/projects",
-      )
-    : `/projects?tags=${tag.code}`;
-
   return (
     <ProjectTagHoverCard tag={tag}>
       <NextLink

--- a/apps/web/src/components/tags/project-tag.tsx
+++ b/apps/web/src/components/tags/project-tag.tsx
@@ -2,9 +2,10 @@
 
 import NextLink from "next/link";
 
-import { ProjectTagHoverCard } from "./project-tag-hover-card";
 import { badgeVariants } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+
+import { ProjectTagHoverCard } from "./project-tag-hover-card";
 
 export function ProjectTag({
   tag,

--- a/apps/web/src/components/tags/project-tag.tsx
+++ b/apps/web/src/components/tags/project-tag.tsx
@@ -1,3 +1,4 @@
+"use client";
 import NextLink from "next/link";
 
 import type { TagFilterState } from "@/components/project-list/project-table";

--- a/packages/db/src/projects/find-with-trends.ts
+++ b/packages/db/src/projects/find-with-trends.ts
@@ -40,8 +40,9 @@ export interface FindProjectsWithTrendsOptions {
   query?: string;
   /**
    * Quality floor: keep only projects with `relevance_score >= 0`.
-   * Disable to query the full catalog, including deprecated projects
-   * with no meaningful signals (used by the `/search` route).
+   * Off by default — the public listing/search shows the full catalog
+   * (curation lives in sort order + visible badges, not a numeric cutoff).
+   * Enable to opt into a "hide low-signal projects" view.
    */
   relevanceFloor?: boolean;
   sort?: TrendsSortKey;
@@ -56,15 +57,17 @@ export type ProjectWithTrends = Awaited<
 /**
  * Web-facing variant of `findProjects()`, backed by the `repo_trends` and
  * `project_trends` cache tables populated daily by the backend tasks.
- * Projects added since the last daily run have no cache row and are not
- * returned; the admin app should keep using `findProjects()`.
+ * `project_trends` is LEFT-joined, so projects added since the last daily run
+ * (no cache row yet) are still returned, with null scores — this keeps the
+ * listing count equal to the tag count. The admin app keeps using
+ * `findProjects()`.
  */
 export async function findProjectsWithTrends({
   db,
   limit = 30,
   page = 1,
   query,
-  relevanceFloor = true,
+  relevanceFloor = false,
   sort = "most-stars",
   tagCodes,
 }: FindProjectsWithTrendsOptions) {
@@ -115,7 +118,7 @@ export async function findProjectsWithTrends({
     })
     .from(projects)
     .innerJoin(repos, eq(projects.repoId, repos.id))
-    .innerJoin(projectTrends, eq(projectTrends.projectId, projects.id))
+    .leftJoin(projectTrends, eq(projectTrends.projectId, projects.id))
     .leftJoin(repoTrends, eq(repoTrends.repoId, repos.id))
     .leftJoin(projectsToTags, eq(projectsToTags.projectId, projects.id))
     .leftJoin(tags, eq(projectsToTags.tagId, tags.id))
@@ -129,7 +132,7 @@ export async function findProjectsWithTrends({
     .select({ count: count() })
     .from(projects)
     .innerJoin(repos, eq(projects.repoId, repos.id))
-    .innerJoin(projectTrends, eq(projectTrends.projectId, projects.id))
+    .leftJoin(projectTrends, eq(projectTrends.projectId, projects.id))
     .leftJoin(repoTrends, eq(repoTrends.repoId, repos.id))
     .where(where);
 

--- a/packages/db/src/tags/find-relevant.ts
+++ b/packages/db/src/tags/find-relevant.ts
@@ -15,7 +15,7 @@ export interface FindRelevantTagsOptions {
   tagCodes?: string[];
   /** Text search on project name/description and repo owner/name, same scoping as findProjectsWithTrends() */
   query?: string;
-  /** Quality floor matching findProjectsWithTrends()'s default; disable for the future /search route */
+  /** Quality floor matching findProjectsWithTrends()'s default (off — full catalog); enable to hide low-signal projects */
   relevanceFloor?: boolean;
   limit?: number;
 }
@@ -35,7 +35,7 @@ export async function findRelevantTags({
   db,
   tagCodes,
   query,
-  relevanceFloor = true,
+  relevanceFloor = false,
   limit = 20,
 }: FindRelevantTagsOptions): Promise<RelevantTag[]> {
   const where = and(
@@ -59,7 +59,7 @@ export async function findRelevantTags({
     .from(tags)
     .innerJoin(projectsToTags, eq(projectsToTags.tagId, tags.id))
     .innerJoin(projects, eq(projects.id, projectsToTags.projectId))
-    .innerJoin(projectTrends, eq(projectTrends.projectId, projects.id))
+    .leftJoin(projectTrends, eq(projectTrends.projectId, projects.id))
     .innerJoin(repos, eq(projects.repoId, repos.id))
     .where(where)
     .groupBy(tags.id)


### PR DESCRIPTION
Closes #426

## Goal

Task 5/7 of the DB-migration umbrella (#413). Make `/projects` show the **full catalog** and fold search into it, so the listing count finally matches the tag count.

Two changes ship together:

### 1. Remove the relevance floor + LEFT-join `project_trends`

`/projects` used to hide any project with `relevance_score < 0` and `INNER JOIN project_trends`, which silently dropped **454 projects globally (210 of them `active`, not deprecated)** and broke a basic invariant — `/tags` reported 658 projects for `react` while the listing showed ~579.

- Drop the `relevance_score >= 0` floor from the public listing (`relevanceFloor` now defaults to `false`; the flag is kept as a soft opt-in for a future "hide low-signal" view, and `relevance_score` is still computed/returned as a signal).
- `project_trends` becomes a **LEFT JOIN** (main + count queries), so brand-new projects with no daily cache row yet still appear — with null scores — instead of being excluded. This restores **listing count == tag count** and makes new projects visible on `/projects?sort=newest`.
- Same treatment applied to `findRelevantTags()` (the "related tags" row) so its counts stay consistent with the listing.
- `noindex` on `?query=` search-result pages only; the bare listing and tag-filtered pages stay indexable.
- Backend diagnostic task null-guards `relevanceScore` now that it can be null.

Curation moves from an opaque numeric cutoff to visible signals — sort order + badges (the explicit `deprecated` badge lands in #428) + a future editorial soft-delete.

### 2. Fix a HoverCard hydration mismatch

While testing, the tag chips on the homepage threw a recoverable hydration error (`server rendered HTML didn't match the client`) inside Radix `HoverCard`/`Popper`, causing the tag subtree to be regenerated on the client — which looked like a tag intermittently "missing" until you navigated. Root cause: the two components that render `ProjectTagHoverCard` (`project-tag.tsx`, `compact-tag-list.tsx`) were Server Components, so the client/server boundary landed *inside* the Radix tree. Marking both wrappers `"use client"` puts the boundary above the HoverCard and resolves the mismatch.

## How to test

**Count invariant** — open `/projects?tags=react` → total should be **658**, matching the `/tags` page (previously ~579).

**New project appears immediately** (the LEFT-join behavior) — a brand-new project with no `project_trends` row should surface on the DB-backed listing:
1. Add a project via the admin app (writes to the DB only).
2. Rebuild + serve: `pnpm -F web build && pnpm -F web start`.
3. Purge the listing cache — it's `"use cache"` + `cacheTag("projects")`, so it won't re-query the DB until revalidated:
   ```
   GET http://localhost:3000/api/revalidate?tag=projects
   ```
4. Open `/projects?sort=newest` → the new project is at/near the top (ordered by `projects.createdAt`), rendering with empty score cells (null trends).
5. `/projects?tags=<one of its tags>` total includes it and still matches the `/tags` count.

> Note: the homepage **"Recently Added Projects"** list is still fed by the static JSON API, so a DB-only project will *not* show there yet — that surface migrates in #460 (Task 8). Verify new-project visibility on `/projects?sort=newest`, not the homepage.

**No hydration error** — homepage tag chips render on first paint with no hydration warning in the console (previously a chip could appear only after navigating).

**noindex scoping** — `/projects?query=react` responds with `robots: noindex`; `/projects` and `/projects?tags=react` remain indexable.

**Backend invariant check:**
```bash
bun run apps/backend/src/cli.ts check-trends-queries --tags react
```

## Out of scope

- Homepage + `/trends/*` migration and the "Popular Tags" count fix → **#460** (Task 8).
- Explicit `deprecated` badge + muted row styling → **#428** (Task 7).
- Cmd+K palette Enter → `/projects?query=` → **#427** (Task 6).

## Screenshots

`/projects?sort=newest` showing a project that has just been added to the DB, before ant snapshot is created:

<img width="1090" height="705" alt="image" src="https://github.com/user-attachments/assets/0313a1f1-0731-4040-b5db-223a7ac9a446" />

<img width="1008" height="719" alt="image" src="https://github.com/user-attachments/assets/579133be-6dca-496b-9f3d-9caeeb6221d0" />


