### PR TITLE
Add UI badges for cold / inactive projects and `scope` search param

### DIFF
--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
+import { getProjectLabel } from "@repo/db/project-trends";
 import {
   findProjectsWithTrends,
   type ProjectWithTrends,
+  resolveScope,
 } from "@repo/db/projects";
 import {
   type TrendsSortKey,
@@ -49,6 +51,12 @@ export const checkTrendsQueriesTask = createTask({
         "Show the full catalog with the relevance floor disabled — the live site default. Pass --no-fullCatalog to preview the legacy floored listing.",
       default: true,
     },
+    scope: {
+      type: String,
+      description:
+        "Which projects to show, as the web listing's `scope` param: 'active' (the site default — hides deprecated, inactive and cold projects) or 'all'.",
+      default: "active",
+    },
     page: {
       type: Number,
       description: "Page number",
@@ -65,12 +73,13 @@ export const checkTrendsQueriesTask = createTask({
     tags: z.string().optional(),
     search: z.string().optional(),
     fullCatalog: z.boolean().optional().default(true),
+    scope: z.enum(["all", "active"]).optional().default("active"),
     page: z.number().optional().default(1),
     limit: z.number().optional().default(0), // shared flag; 0 means "not provided"
     columns: z.string().optional(),
   }),
   run: async ({ db, logger }, flags) => {
-    const { sort, search, fullCatalog, page } = flags;
+    const { sort, search, fullCatalog, scope, page } = flags;
     const limit = flags.limit || 25;
     const tagCodes = flags.tags
       ?.split(",")
@@ -84,10 +93,18 @@ export const checkTrendsQueriesTask = createTask({
       tagCodes,
       page,
       limit,
+      scope,
     };
-    const [floored, full] = await Promise.all([
+    // A text search always searches the whole catalog, whatever `--scope` says.
+    const effectiveScope = resolveScope(scope, search);
+    const [floored, full, scopeAll] = await Promise.all([
       findProjectsWithTrends({ ...options, relevanceFloor: true }),
       findProjectsWithTrends({ ...options, relevanceFloor: false }),
+      // Only to report how much the scope filter removes — the web listing
+      // doesn't need this, `scope` is just another filter there.
+      effectiveScope === "active"
+        ? findProjectsWithTrends({ ...options, scope: "all", limit: 1 })
+        : undefined,
     ]);
     const { projects, total } = fullCatalog ? full : floored;
 
@@ -111,12 +128,18 @@ export const checkTrendsQueriesTask = createTask({
     logger.info(
       `${projects.length} projects shown (page ${page}), ${total} matching in total`,
     );
+    if (scopeAll) {
+      logger.info(
+        `The "active" scope hides ${scopeAll.total - total} of the ${scopeAll.total} matching projects (deprecated, inactive or cold)`,
+      );
+    }
     logger.info(
       `The relevance floor hides ${full.total - floored.total} of the ${full.total} matching projects`,
     );
 
     const violations = [
       ...checkRelevanceFloor(projects, fullCatalog),
+      ...checkScope(projects, effectiveScope),
       ...checkSortOrder(projects, sort),
       ...checkTagFilter(projects, tagCodes),
       ...(full.total >= floored.total
@@ -153,6 +176,29 @@ function checkRelevanceFloor(
     .map(
       (project) =>
         `"${project.slug}" has a negative relevance score (${project.relevanceScore}) but the floor is enabled`,
+    );
+}
+
+/**
+ * The `scope: "active"` filter is expressed in SQL while the badge that names
+ * the same projects is expressed in TypeScript, so the two can drift. This
+ * catches that directly: under the filter, no row may carry a warning badge.
+ */
+function checkScope(projects: ProjectWithTrends[], scope: "all" | "active") {
+  if (scope === "all") return [];
+  return projects
+    .map((project) => ({
+      project,
+      label: getProjectLabel({
+        status: project.status,
+        activityScore: project.activityScore,
+        yearlyStars: project.trends?.yearly,
+      }),
+    }))
+    .filter(({ label }) => label !== null)
+    .map(
+      ({ project, label }) =>
+        `"${project.slug}" is labelled "${label}" but the "active" scope should have hidden it`,
     );
 }
 
@@ -259,6 +305,14 @@ const COLUMNS = {
   createdAt: (p: ProjectWithTrends) =>
     p.repo.created_at.toISOString().slice(0, 10),
   tags: (p: ProjectWithTrends) => p.tags.join(", "),
+  // The badge the web listing renders for this row, so thresholds can be
+  // eyeballed across the whole catalog before tuning them in the browser.
+  label: (p: ProjectWithTrends) =>
+    getProjectLabel({
+      status: p.status,
+      activityScore: p.activityScore,
+      yearlyStars: p.trends?.yearly,
+    }),
 } as const satisfies Record<
   string,
   (p: ProjectWithTrends, ctx: RowContext) => unknown

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -79,6 +79,15 @@ async function fetchOgProjects(searchState: TrendsProjectSearchState) {
       limit: NUMBER_OF_PROJECTS,
       page,
       query,
+      // `scope` is deliberately NOT forwarded, so this always previews the
+      // default (active) view. The image is a 3-row teaser, not a mirror of the
+      // page, and previewing maintained projects is the right thing to put in
+      // front of someone who hasn't clicked yet.
+      //
+      // Consequence, accepted: on an explicit `?scope=all` page a deprecated or
+      // cold project can sit in the top 3 and won't appear here. Search pages
+      // are unaffected — passing `query` makes `resolveScope()` force `"all"` on
+      // both sides. Forwarding it would double the cached image variants.
       sort,
       tagCodes,
     }),

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -29,8 +29,10 @@
   --color-secondary-hover: var(--secondary-hover);
   --color-secondary-foreground: var(--secondary-foreground);
 
-  --color-destructive: hsl(var(--destructive));
-  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  /* `hsl()` here used to wrap an `oklch()` value, which is invalid CSS: every
+     `bg-destructive` resolved to transparent. */
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
 
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
@@ -137,6 +139,7 @@
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.75 0.183 55.934);
@@ -206,6 +209,9 @@
   --muted: oklch(0.274 0.006 286.033);
   --muted-foreground: oklch(0.705 0.015 286.067);
   --destructive: oklch(0.704 0.191 22.216);
+  /* Dark theme's destructive is a light red: dark text on it reaches ~4.8:1,
+     white only ~3.2:1, which badge-sized text can't afford. */
+  --destructive-foreground: oklch(0.141 0.005 285.823);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.408 0.123 38.172);
   --chart-1: oklch(0.837 0.128 66.29);

--- a/apps/web/src/app/projects/[slug]/project-details-github/monthly-trends-chart.tsx
+++ b/apps/web/src/app/projects/[slug]/project-details-github/monthly-trends-chart.tsx
@@ -53,7 +53,8 @@ const BarGraph = ({ items, ...rest }: BarGraphProps) => {
   const values = items
     .map(({ value }) => value)
     .filter((value) => value !== undefined);
-  const maxValue = Math.max(...(values as number[]));
+  const positiveValues = (values as number[]).filter((v) => v > 0);
+  const maxValue = Math.max(0, ...positiveValues) || 1;
 
   const [selectedItem, setSelectedItem] = useState<BarGraphItem | undefined>(
     undefined,
@@ -66,7 +67,10 @@ const BarGraph = ({ items, ...rest }: BarGraphProps) => {
         {items.map((item) => {
           const { year, month, value } = item;
           const maxHeight = 120;
-          const height = Math.round(((value || 0) / maxValue) * maxHeight);
+          const height =
+            value && value > 0
+              ? Math.round((value / maxValue) * maxHeight)
+              : 0;
 
           return (
             <div
@@ -133,6 +137,7 @@ const MonthSummary = ({
 const GraphBar = ({
   height,
   value,
+  unit,
   showPlusSymbol,
   onClick,
 }: {
@@ -142,8 +147,14 @@ const GraphBar = ({
   month: number;
   onClick?: () => void;
 } & FormattingOptions) => {
-  if (!value) {
-    return <EmptyGraphBar value={value} />;
+  if (!value || value <= 0) {
+    return (
+      <EmptyGraphBar
+        value={value}
+        unit={unit}
+        showPlusSymbol={showPlusSymbol}
+      />
+    );
   }
 
   const formattedValue = formatValue(value, { showPlusSymbol });
@@ -163,12 +174,21 @@ const GraphBar = ({
   );
 };
 
-const EmptyGraphBar = ({ value }: { value: number | undefined }) => {
+const EmptyGraphBar = ({
+  value,
+  showPlusSymbol,
+}: {
+  value: number | undefined;
+} & FormattingOptions) => {
+  const label =
+    value === undefined
+      ? "N/A"
+      : value < 0
+        ? formatValue(value, { showPlusSymbol })
+        : 0;
   return (
     <>
-      <BarTopLabel className="text-muted-foreground">
-        {value === undefined ? "N/A" : 0}
-      </BarTopLabel>
+      <BarTopLabel className="text-muted-foreground">{label}</BarTopLabel>
       <div className="mt-1 h-px w-3/4 max-w-8 border-(--graphBackgroundColor1) border-b border-dashed" />
     </>
   );

--- a/apps/web/src/app/projects/[slug]/project-details-github/monthly-trends-chart.tsx
+++ b/apps/web/src/app/projects/[slug]/project-details-github/monthly-trends-chart.tsx
@@ -68,9 +68,7 @@ const BarGraph = ({ items, ...rest }: BarGraphProps) => {
           const { year, month, value } = item;
           const maxHeight = 120;
           const height =
-            value && value > 0
-              ? Math.round((value / maxValue) * maxHeight)
-              : 0;
+            value && value > 0 ? Math.round((value / maxValue) * maxHeight) : 0;
 
           return (
             <div

--- a/apps/web/src/app/projects/[slug]/project-header.tsx
+++ b/apps/web/src/app/projects/[slug]/project-header.tsx
@@ -8,7 +8,13 @@ import {
   type ProjectDetails,
 } from "@repo/db/projects";
 
-import { GitHubIcon, HomeIcon, NpmIcon, ProjectLogo } from "@/components/core";
+import {
+  GitHubIcon,
+  HomeIcon,
+  NpmIcon,
+  ProjectLabel,
+  ProjectLogo,
+} from "@/components/core";
 import { ProjectTagGroup } from "@/components/tags/project-tag-group";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
@@ -40,13 +46,19 @@ export function ProjectHeader({ project }: Props) {
         <div className="flex flex-col justify-center space-y-4 px-4">
           <div className="flex flex-col justify-between sm:flex-row sm:items-center">
             <h2 className="font-serif text-4xl">{project.name}</h2>
-            {isGPLProject(project) && (
-              <div>
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Deprecation is the one signal a visitor arriving from a shared
+                  link can't infer from the charts below. The score labels stay
+                  listing-only: this page shows the raw signals already. */}
+              {project.status === "deprecated" && (
+                <ProjectLabel label="deprecated" className="text-base" />
+              )}
+              {isGPLProject(project) && (
                 <Badge variant="destructive" className="text-base">
                   {getLicenseShortName(project.repo.license)}
                 </Badge>
-              </div>
-            )}
+              )}
+            </div>
           </div>
           <div>{getProjectDescription(project)}</div>
           <div>

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -93,7 +93,7 @@ function getPageDescription(
   data: ProjectsPageData,
   searchState: TrendsProjectSearchState,
 ) {
-  const { query, sort } = searchState;
+  const { query, sort, scope } = searchState;
   const NUMBER_OF_PROJECTS = 8;
   const { projects, selectedTags: tags, total } = data;
   const projectNames = projects
@@ -104,7 +104,11 @@ function getPageDescription(
   const sortOptionLabel = getTrendsSortOptionByKey(sort).label.toLowerCase();
 
   if (!query && tags.length === 0) {
-    return `All the ${total} projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`;
+    // "All the N projects" would be a false claim under the default `active`
+    // scope, which hides deprecated, inactive and cold projects.
+    return scope === "all"
+      ? `All the ${total} projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`
+      : `${total} actively maintained projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`;
   }
   if (!query && tags.length > 0) {
     return `${total} projects tagged with ${tagNames}, ${sortOptionLabel}: ${projectNames}...`;
@@ -310,12 +314,14 @@ async function fetchPageData(
   cacheLife("hours");
   cacheTag("projects");
 
-  const { tags: tagCodes, sort, page, limit, query } = searchState;
+  const { tags: tagCodes, sort, page, limit, query, scope } = searchState;
 
   const [{ projects: rows, total }, allTags, relevantTags] = await Promise.all([
-    findProjectsWithTrends({ db, limit, page, query, sort, tagCodes }),
+    findProjectsWithTrends({ db, limit, page, query, scope, sort, tagCodes }),
     findTags(),
-    findRelevantTags({ db, tagCodes, query }),
+    // Same `scope` as the listing: a suggested tag whose projects are all
+    // filtered out would lead to an empty page.
+    findRelevantTags({ db, tagCodes, query, scope }),
   ]);
 
   const tagsByCode = buildTagsByCode(allTags);

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -4,7 +4,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import NextLink from "next/link";
 
 import { db } from "@repo/db";
-import { findProjectsWithTrends } from "@repo/db/projects";
+import { findProjectsWithTrends, resolveScope } from "@repo/db/projects";
 import { findRelevantTags, findTags } from "@repo/db/tags";
 
 import {
@@ -15,6 +15,7 @@ import {
 import { PlusIcon, TagIcon, XMarkIcon } from "@/components/core";
 import { PageHeading } from "@/components/core/typography";
 import { TrendsProjectPaginatedList } from "@/components/project-list/trends-project-paginated-list";
+import { TrendsProjectScopePicker } from "@/components/project-list/trends-scope-picker";
 import { getTrendsSortOptionByKey } from "@/components/project-list/trends-sort-order-options";
 import { badgeVariants } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
@@ -146,6 +147,7 @@ async function ProjectsPageContent(props: PageProps) {
         searchState={searchState}
         tags={selectedTags}
         total={total}
+        buildPageURL={buildPageURL}
       />
       {(selectedTags.length > 0 || query) && (
         <CurrentTags
@@ -175,61 +177,103 @@ function ProjectPageHeader({
   tags,
   searchState,
   total,
+  buildPageURL,
 }: {
   tags: TagSummary[];
   searchState: TrendsProjectSearchState;
   total: number;
+  buildPageURL: TrendsProjectSearchUrlBuilder;
 }) {
-  const { query } = searchState;
-  const showingAllProjects = !query && tags.length === 0;
-  if (showingAllProjects) {
+  const { query, scope } = searchState;
+  // The schema normalises an empty query away, so this is just "is a query set".
+  const isSearching = Boolean(query);
+  // The scope the count was actually produced under, not the one in the URL: a
+  // text query forces `"all"`, so a search page must not claim "active
+  // projects" while listing the whole catalog.
+  const effectiveScope = resolveScope(scope, query);
+  // Searching always covers the whole catalog, so the picker would be inert
+  // there — on those pages the subtitle carries the count alone.
+  const scopePicker = isSearching ? undefined : (
+    <TrendsProjectScopePicker value={scope} buildPageURL={buildPageURL} />
+  );
+  if (!isSearching && tags.length === 0) {
     return (
       <PageHeading
-        title={
-          <>
-            All Projects
-            <ShowNumberOfProject count={total} />
-          </>
+        // The title names the scope, so the count below it needs no qualifier:
+        // "Active Projects" over "1,607 projects", never "1,607 active
+        // projects", which would say "active" twice.
+        title={effectiveScope === "active" ? "Active Projects" : "All Projects"}
+        subtitle={
+          <HeadingDetails
+            count={total}
+            noun="project"
+            scopePicker={scopePicker}
+          />
         }
       />
     );
   }
-  if (query === "") {
+  if (!isSearching) {
     return (
       <PageHeading
-        title={
-          <>
-            {tags.map((tag) => tag.name).join(" + ")}
-            <ShowNumberOfProject count={total} />
-          </>
+        title={tags.map((tag) => tag.name).join(" + ")}
+        subtitle={
+          <HeadingDetails
+            count={total}
+            // The title is tag names, so the scope has to ride on the count.
+            noun={getNoun(effectiveScope)}
+            scopePicker={scopePicker}
+          />
         }
-        icon={<TagIcon className="size-8" />}
+        icon={<TagIcon className="size-6 sm:size-8" />}
       />
     );
   }
   return (
     <PageHeading
-      title={
-        <>
-          Search results
-          <ShowNumberOfProject count={total} />
-        </>
-      }
+      title="Search results"
+      subtitle={<HeadingDetails count={total} noun={getNoun(effectiveScope)} />}
     />
   );
 }
 
-function ShowNumberOfProject({ count }: { count: number }) {
+function getNoun(scope: TrendsProjectSearchState["scope"]) {
+  return scope === "active" ? "active project" : "project";
+}
+
+/**
+ * The second line of the heading: how many results, and the control that
+ * changes them. Its own row rather than trailing the `h1` — the count is
+ * metadata about the results, not part of the page's name, and at heading size
+ * it wrapped badly on phones.
+ *
+ * Some form of the scope always reaches the heading, in the title or in the
+ * noun. That is what lets `TrendsProjectScopePicker` shrink to an icon: the
+ * heading reports the state, so the control only has to offer the change. Same
+ * wording as `getPageDescription()` — "active" means exactly "what the filter
+ * keeps".
+ */
+function HeadingDetails({
+  count,
+  noun,
+  scopePicker,
+}: {
+  count: number;
+  noun: string;
+  scopePicker?: React.ReactNode;
+}) {
   return (
-    <>
-      <span className="px-2 text-(--icon-color)">•</span>
-      <span className="text-muted-foreground">
-        {count === 1
-          ? "One project"
-          : `${formatNumber(count, "full")} projects`}
-      </span>
-    </>
+    <div className="flex items-center gap-2">
+      <span>{formatCount(count, noun)}</span>
+      {scopePicker}
+    </div>
   );
+}
+
+function formatCount(count: number, noun: string) {
+  return count === 1
+    ? `One ${noun}`
+    : `${formatNumber(count, "full")} ${noun}s`;
 }
 
 function RelevantTags({

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -105,10 +105,14 @@ function getPageDescription(
 
   if (!query && tags.length === 0) {
     // "All the N projects" would be a false claim under the default `active`
-    // scope, which hides deprecated, inactive and cold projects.
+    // scope, which hides deprecated, inactive and cold projects. "Active" is
+    // the word the scope picker uses, and it means exactly "what this filter
+    // keeps" — unlike "actively maintained", which would describe the rows
+    // correctly but imply the count covers every maintained project (it does
+    // not: maintained-but-cold projects are filtered out too).
     return scope === "all"
       ? `All the ${total} projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`
-      : `${total} actively maintained projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`;
+      : `${total} active projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`;
   }
   if (!query && tags.length > 0) {
     return `${total} projects tagged with ${tagNames}, ${sortOptionLabel}: ${projectNames}...`;

--- a/apps/web/src/app/projects/project-adapter.ts
+++ b/apps/web/src/app/projects/project-adapter.ts
@@ -1,12 +1,15 @@
+import type { ProjectStatus } from "@repo/db/constants";
 import type { ProjectWithTrends } from "@repo/db/projects";
 
 /**
- * `BestOfJS.Project` shape plus the two trends-only scores (`popularityScore`,
- * `activityScore`) that don't exist on the shared static-JSON type — kept as a
- * local intersection rather than widening `BestOfJS.Project` for every consumer.
+ * `BestOfJS.Project` shape plus `activityScore`, which doesn't exist on the
+ * shared static-JSON type — kept as a local intersection rather than widening
+ * `BestOfJS.Project` for every consumer. With `status` and `trends.yearly` it is
+ * everything `getProjectLabel()` needs.
  */
-export type TrendsProject = BestOfJS.Project & {
-  popularityScore: number | null;
+export type TrendsProject = Omit<BestOfJS.Project, "status"> & {
+  /** Narrowed from the static-JSON `string`: the DB column is an enum. */
+  status: ProjectStatus;
   activityScore: number | null;
 };
 
@@ -59,7 +62,6 @@ export function toTrendsProject(
     tags: row.tags
       .map((code) => tagsByCode.get(code))
       .filter((tag): tag is BestOfJS.Tag => Boolean(tag)),
-    popularityScore: row.popularityScore,
     activityScore: row.activityScore,
   };
 }

--- a/apps/web/src/app/projects/trends-project-search-state.ts
+++ b/apps/web/src/app/projects/trends-project-search-state.ts
@@ -14,7 +14,16 @@ export const trendsProjectSearchStateSchema = paginationSchema.extend({
   tags: z
     .preprocess(makeArray, z.array(z.string())) // accept string or array and convert to array
     .default([]),
-  query: z.string().optional(),
+  // An absent query and an empty one both mean "not searching", and the UI
+  // produces both: clearing the text-query chip sets `query: ""`, which `qss`
+  // encodes as a bare `?query=`. Collapsing the two here leaves consumers
+  // (`resolveScope()`, the page heading, the OG route) a single representation
+  // to test — the alternative already caused one bug, where a check for `""`
+  // sent every tag-filtered page down the "Search results" branch.
+  query: z
+    .string()
+    .optional()
+    .transform((value) => value || undefined),
   sort: trendsSortKeySchema.catch("most-stars").default("most-stars"),
   // Defaults to the filtered view: a bare /projects URL hides the projects the
   // UI would badge as a warning, and `?scope=all` opts into the full catalog.

--- a/apps/web/src/app/projects/trends-project-search-state.ts
+++ b/apps/web/src/app/projects/trends-project-search-state.ts
@@ -16,6 +16,9 @@ export const trendsProjectSearchStateSchema = paginationSchema.extend({
     .default([]),
   query: z.string().optional(),
   sort: trendsSortKeySchema.catch("most-stars").default("most-stars"),
+  // Defaults to the filtered view: a bare /projects URL hides the projects the
+  // UI would badge as a warning, and `?scope=all` opts into the full catalog.
+  scope: z.enum(["all", "active"]).catch("active").default("active"),
 });
 
 export type TrendsProjectSearchState = z.infer<

--- a/apps/web/src/components/core/index.tsx
+++ b/apps/web/src/components/core/index.tsx
@@ -1,3 +1,4 @@
 export * from "./icons";
 export * from "./project";
+export * from "./project-labels";
 export * from "./project-logo";

--- a/apps/web/src/components/core/project-labels.tsx
+++ b/apps/web/src/components/core/project-labels.tsx
@@ -1,0 +1,58 @@
+import type { ProjectLabelKey } from "@repo/db/project-trends";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type LabelConfig = {
+  text: string;
+  /** Native `title`: states the underlying fact, with no JS shipped. */
+  title: string;
+  /** Tailwind's default palette — no theme tokens needed, both modes covered. */
+  className: string;
+};
+
+/**
+ * Display copy and colour for the key `getProjectLabel()` returns. Every label
+ * is a caution, so they share a cool-to-red range: red for curated deprecation,
+ * slate for neglect, sky for lost momentum.
+ */
+const LABELS: Record<ProjectLabelKey, LabelConfig> = {
+  deprecated: {
+    text: "deprecated",
+    title: "This project is no longer maintained by its authors.",
+    className:
+      "border-red-300 bg-red-100 text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-200",
+  },
+  inactive: {
+    text: "inactive",
+    title: "No commit for more than a year.",
+    className:
+      "border-slate-300 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300",
+  },
+  cold: {
+    text: "cold",
+    title: "Fewer than 50 new stars over the past year.",
+    className:
+      "border-sky-300 bg-sky-100 text-sky-900 dark:border-sky-900 dark:bg-sky-950 dark:text-sky-200",
+  },
+};
+
+export function ProjectLabel({
+  label,
+  className,
+}: {
+  label: ProjectLabelKey | null;
+  className?: string;
+}) {
+  if (!label) return null;
+  const config = LABELS[label];
+  return (
+    <Badge
+      variant="outline"
+      title={config.title}
+      className={cn("shrink-0 whitespace-nowrap", config.className, className)}
+    >
+      {config.text}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/project-list/project-table.tsx
+++ b/apps/web/src/components/project-list/project-table.tsx
@@ -24,19 +24,27 @@ import { cn } from "@/lib/utils";
 /** Shared shape both the old (static-JSON) and new (DB-trends) search states satisfy. */
 export type TagFilterState = PaginationProps & { tags: string[] };
 
-type Props<T extends TagFilterState = TagFilterState> = {
-  projects: BestOfJS.Project[];
+type Props<
+  P extends BestOfJS.Project = BestOfJS.Project,
+  T extends TagFilterState = TagFilterState,
+> = {
+  projects: P[];
   buildPageURL?: PageSearchUrlBuilder<T>;
   footer?: React.ReactNode;
-  metricsCell?: (project: BestOfJS.Project) => React.ReactNode;
+  metricsCell?: (project: P) => React.ReactNode;
+  /**
+   * Status/score badges rendered next to the project name. A render prop
+   * because the labels need the trends scores, which only the DB-backed
+   * surfaces have — the static-JSON callers just omit it.
+   */
+  labels?: (project: P) => React.ReactNode;
   showDetails?: boolean;
 };
 
-export function ProjectTable<T extends TagFilterState = TagFilterState>({
-  projects,
-  footer,
-  ...otherProps
-}: Props<T>) {
+export function ProjectTable<
+  P extends BestOfJS.Project = BestOfJS.Project,
+  T extends TagFilterState = TagFilterState,
+>({ projects, footer, ...otherProps }: Props<P, T>) {
   return (
     <table className="w-full">
       <tbody className="[&_tr:last-child]:border-0">
@@ -64,37 +72,54 @@ export function ProjectTable<T extends TagFilterState = TagFilterState>({
   );
 }
 
-type RowProps<T extends TagFilterState = TagFilterState> = Pick<
-  Props<T>,
-  "buildPageURL" | "metricsCell" | "showDetails"
+type RowProps<
+  P extends BestOfJS.Project = BestOfJS.Project,
+  T extends TagFilterState = TagFilterState,
+> = Pick<
+  Props<P, T>,
+  "buildPageURL" | "metricsCell" | "labels" | "showDetails"
 > & {
-  project: BestOfJS.Project;
+  project: P;
 };
-function ProjectTableRow<T extends TagFilterState = TagFilterState>({
+function ProjectTableRow<
+  P extends BestOfJS.Project = BestOfJS.Project,
+  T extends TagFilterState = TagFilterState,
+>({
   project,
   buildPageURL,
   showDetails = true,
   metricsCell,
-}: RowProps<T>) {
+  labels,
+}: RowProps<P, T>) {
   const path = `/projects/${project.slug}`;
+  // De-emphasize the whole row, but never the badges: the `deprecated` badge
+  // has to stay vivid, so the muting is applied per element instead of as a
+  // single `opacity` on the `<tr>`.
+  const isDeprecated = project.status === "deprecated";
 
   return (
     <tr data-testid="project-card" className="border-b">
       <Cell className="w-[50px] pl-4 sm:p-4">
-        <NextLink href={path}>
+        <NextLink href={path} className={cn(isDeprecated && "grayscale")}>
           <ProjectLogo project={project} size={48} />
         </NextLink>
       </Cell>
 
       <Cell className="max-w-0 py-4 pl-4 md:pl-2">
-        <div className="relative flex items-center space-x-2">
+        <div className="relative flex flex-wrap items-center gap-2">
           <NextLink
             href={path}
-            className={linkVariants({ variant: "project" })}
+            className={cn(
+              linkVariants({ variant: "project" }),
+              isDeprecated && "text-muted-foreground",
+            )}
           >
             {project.name}
           </NextLink>
-          <div className="hidden w-full space-x-1 md:flex">
+          {labels?.(project)}
+          {/* `grow`, not `w-full`: the row wraps now (badges can be long), and
+              a 100%-width child would always claim a line of its own. */}
+          <div className="hidden grow space-x-1 md:flex">
             <a
               href={"https://github.com/" + project.full_name}
               aria-label="GitHub repository"
@@ -123,20 +148,30 @@ function ProjectTableRow<T extends TagFilterState = TagFilterState>({
             )}
           </div>
           {metricsCell && (
-            <div className="flex w-full justify-end pr-4 text-right md:hidden">
+            <div className="flex grow justify-end pr-4 text-right md:hidden">
               {metricsCell(project)}
             </div>
           )}
         </div>
 
-        <div className="mt-2 mb-4 truncate pr-4 font-serif text-sm sm:pr-0">
+        <div
+          className={cn(
+            "mt-2 mb-4 truncate pr-4 font-serif text-sm sm:pr-0",
+            isDeprecated && "text-muted-foreground",
+          )}
+        >
           {project.description}
         </div>
         <ProjectTagGroup tags={project.tags} buildPageURL={buildPageURL} />
       </Cell>
 
       {showDetails && (
-        <Cell className="hidden w-[180px] space-y-2 p-4 text-sm md:table-cell">
+        <Cell
+          className={cn(
+            "hidden w-[180px] space-y-2 p-4 text-sm md:table-cell",
+            isDeprecated && "text-muted-foreground",
+          )}
+        >
           {project.pushed_at ? (
             <div>
               Pushed{" "}
@@ -160,7 +195,12 @@ function ProjectTableRow<T extends TagFilterState = TagFilterState>({
       )}
 
       {metricsCell && (
-        <Cell className="hidden w-[128px] p-4 text-right md:table-cell">
+        <Cell
+          className={cn(
+            "hidden w-[128px] p-4 text-right md:table-cell",
+            isDeprecated && "opacity-70",
+          )}
+        >
           {metricsCell(project)}
         </Cell>
       )}

--- a/apps/web/src/components/project-list/trends-project-paginated-list.tsx
+++ b/apps/web/src/components/project-list/trends-project-paginated-list.tsx
@@ -1,7 +1,11 @@
+import { getProjectLabel } from "@repo/db/project-trends";
+
+import type { TrendsProject } from "@/app/projects/project-adapter";
 import type {
   TrendsProjectSearchState,
   TrendsProjectSearchUrlBuilder,
 } from "@/app/projects/trends-project-search-state";
+import { ProjectLabel } from "@/components/core";
 import { Card, CardHeader } from "@/components/ui/card";
 
 import {
@@ -10,10 +14,11 @@ import {
 } from "../core/pagination/pagination-controls";
 import { computePaginationState } from "../core/pagination/pagination-state";
 import { ProjectScore, ProjectTable } from "./project-table";
+import { TrendsProjectScopePicker } from "./trends-scope-picker";
 import { TrendsProjectSortOrderPicker } from "./trends-sort-order-picker";
 
 type Props = {
-  projects: BestOfJS.Project[];
+  projects: TrendsProject[];
   searchState: TrendsProjectSearchState;
   buildPageURL: TrendsProjectSearchUrlBuilder;
   total: number;
@@ -24,7 +29,7 @@ export const TrendsProjectPaginatedList = ({
   searchState,
   total,
 }: Props) => {
-  const { page, limit, sort } = searchState;
+  const { page, limit, sort, scope, query } = searchState;
   const showPagination = total > limit;
   const showSortOptions = total > 1;
   const paginationState = computePaginationState({ page, limit, total });
@@ -39,29 +44,46 @@ export const TrendsProjectPaginatedList = ({
 
   return (
     <Card>
-      <CardHeader>
-        {(showSortOptions || showPagination) && (
-          <div className="flex w-full flex-col justify-between gap-4 md:flex-row">
+      <CardHeader className="space-y-3">
+        <div className="flex w-full flex-col justify-between gap-4 md:flex-row md:items-center">
+          <div className="flex flex-wrap items-center gap-3">
             {showSortOptions && (
               <TrendsProjectSortOrderPicker
                 value={sort}
                 buildPageURL={buildPageURL}
               />
             )}
-            {showPagination && (
-              <TopPaginationControls
-                paginationState={paginationState}
+            {/* A text query always searches the whole catalog (see
+                `resolveScope()`), so the picker would be inert here. */}
+            {!query && (
+              <TrendsProjectScopePicker
+                value={scope}
                 buildPageURL={buildPageURL}
               />
             )}
           </div>
-        )}
+          {showPagination && (
+            <TopPaginationControls
+              paginationState={paginationState}
+              buildPageURL={buildPageURL}
+            />
+          )}
+        </div>
       </CardHeader>
       <ProjectTable
         projects={projects}
         buildPageURL={buildPageURL}
         metricsCell={(project) => (
           <ProjectScore project={project} sort={sort} />
+        )}
+        labels={(project) => (
+          <ProjectLabel
+            label={getProjectLabel({
+              status: project.status,
+              activityScore: project.activityScore,
+              yearlyStars: project.trends.yearly,
+            })}
+          />
         )}
         footer={
           <div className="flex justify-end">

--- a/apps/web/src/components/project-list/trends-project-paginated-list.tsx
+++ b/apps/web/src/components/project-list/trends-project-paginated-list.tsx
@@ -14,7 +14,6 @@ import {
 } from "../core/pagination/pagination-controls";
 import { computePaginationState } from "../core/pagination/pagination-state";
 import { ProjectScore, ProjectTable } from "./project-table";
-import { TrendsProjectScopePicker } from "./trends-scope-picker";
 import { TrendsProjectSortOrderPicker } from "./trends-sort-order-picker";
 
 type Props = {
@@ -29,7 +28,7 @@ export const TrendsProjectPaginatedList = ({
   searchState,
   total,
 }: Props) => {
-  const { page, limit, sort, scope, query } = searchState;
+  const { page, limit, sort } = searchState;
   const showPagination = total > limit;
   const showSortOptions = total > 1;
   const paginationState = computePaginationState({ page, limit, total });
@@ -46,18 +45,13 @@ export const TrendsProjectPaginatedList = ({
     <Card>
       <CardHeader className="space-y-3">
         <div className="flex w-full flex-col justify-between gap-4 md:flex-row md:items-center">
+          {/* Kept as a wrapper even with a single child: when `showSortOptions`
+              is false it holds the left column open so the pagination info
+              stays right-aligned. */}
           <div className="flex flex-wrap items-center gap-3">
             {showSortOptions && (
               <TrendsProjectSortOrderPicker
                 value={sort}
-                buildPageURL={buildPageURL}
-              />
-            )}
-            {/* A text query always searches the whole catalog (see
-                `resolveScope()`), so the picker would be inert here. */}
-            {!query && (
-              <TrendsProjectScopePicker
-                value={scope}
                 buildPageURL={buildPageURL}
               />
             )}

--- a/apps/web/src/components/project-list/trends-scope-picker.tsx
+++ b/apps/web/src/components/project-list/trends-scope-picker.tsx
@@ -1,23 +1,46 @@
+import { CheckIcon, ListFilterIcon } from "lucide-react";
 import NextLink from "next/link";
 
 import type { ProjectScope } from "@repo/db/projects";
 
 import type { TrendsProjectSearchUrlBuilder } from "@/app/projects/trends-project-search-state";
-import { buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
-const OPTIONS: { scope: ProjectScope; label: string; title: string }[] = [
-  {
-    scope: "all",
-    label: "All projects",
-    title:
-      "Show the full catalog, including deprecated and low-signal projects",
-  },
+import { ChevronDownIcon } from "../core";
+
+/**
+ * The default scope comes first: a bare `/projects` URL is `active`, so reading
+ * top-to-bottom goes from the curated list to the full catalog, which is also
+ * the direction the result count moves.
+ *
+ * The descriptions are the badge legend. Each listing row carries at most one
+ * of `deprecated` / `inactive` / `cold`, and "Active only" hides exactly those
+ * rows — so the filter definition and the legend are the same sentence, and
+ * this menu is the only place either one is spelled out for touch users.
+ */
+const OPTIONS: {
+  scope: ProjectScope;
+  label: string;
+  description: string;
+}[] = [
   {
     scope: "active",
     label: "Active only",
-    title:
-      "Hide deprecated projects, projects with no commit for over a year, and projects gaining under 50 stars a year",
+    description: "Hides deprecated, inactive and cold projects",
+  },
+  {
+    scope: "all",
+    label: "All projects",
+    description: "The full catalog, with a badge on every flagged project",
   },
 ];
 
@@ -27,46 +50,68 @@ type Props = {
 };
 
 /**
- * Two-state switch over the listing's `scope`. A pair of links rather than a
- * client component, like `TrendsProjectSortOrderPicker` — the whole listing is
+ * Picks the listing's `scope`. A dropdown rather than a visible switch: it is
+ * an advanced option that shouldn't outweigh the sort picker, and the page
+ * heading already states the current scope in words ("1,607 active projects"),
+ * so the control only has to offer the change.
+ *
+ * The items are links, not client-side state — the whole listing is
  * server-rendered, so navigation is what applies the filter.
  */
 export function TrendsProjectScopePicker({ value, buildPageURL }: Props) {
   return (
-    // `nav`, not a `role="group"` div: these are links that navigate, and a
-    // labelled landmark is the semantic fit (also what biome's a11y rule wants).
-    // `h-9` matches the sort picker's `Button` (also h-9, border-box), so the
-    // two controls line up; the links stretch to fill it.
-    <nav
-      className="inline-flex h-9 overflow-hidden rounded-md border"
-      aria-label="Which projects to show"
-    >
-      {OPTIONS.map(({ scope, label, title }) => {
-        const isCurrent = scope === value;
-        const url = buildPageURL((state) => ({
-          ...state,
-          scope,
-          // Filtering shrinks the result set: the current page may not exist.
-          page: 1,
-        }));
-        return (
-          <NextLink
-            key={scope}
-            href={url}
-            title={title}
-            aria-current={isCurrent ? "true" : undefined}
-            className={cn(
-              buttonVariants({ variant: "ghost", size: "sm" }),
-              // `h-full` overrides the `sm` size's `h-8` (tailwind-merge keeps
-              // the last height), so each link fills the 36px container.
-              "h-full rounded-none border-0 font-sans",
-              isCurrent && "bg-secondary text-secondary-foreground",
-            )}
-          >
-            {label}
-          </NextLink>
-        );
-      })}
-    </nav>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          // Icon-only: the trigger has no accessible name of its own.
+          aria-label="Change which projects are shown"
+        >
+          <ListFilterIcon aria-hidden="true" />
+          <ChevronDownIcon className="size-4" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[280px]">
+        <DropdownMenuLabel>Which projects to show</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {OPTIONS.map(({ scope, label, description }) => {
+          const isCurrent = scope === value;
+          const url = buildPageURL((state) => ({
+            ...state,
+            scope,
+            // Filtering shrinks the result set: the current page may not exist.
+            page: 1,
+          }));
+          return (
+            // `inset` reserves the left gutter on both items, so the labels
+            // line up whether or not the check is rendered.
+            <DropdownMenuItem key={scope} asChild inset>
+              <NextLink
+                href={url}
+                aria-current={isCurrent ? "true" : undefined}
+                className="items-start"
+              >
+                {/* The indicator slot of `DropdownMenuCheckboxItem`, hand-rolled:
+                    these are links, so there is no Radix `ItemIndicator` to
+                    drive it. `text-foreground` opts out of the muted `svg`
+                    colour `DropdownMenuItem` applies to unclassed icons. */}
+                {isCurrent && (
+                  <CheckIcon className="absolute top-2 left-2 size-4 text-foreground" />
+                )}
+                <div className="flex flex-col gap-0.5">
+                  <span className={cn(isCurrent && "font-medium")}>
+                    {label}
+                  </span>
+                  <span className="whitespace-normal text-muted-foreground text-xs">
+                    {description}
+                  </span>
+                </div>
+              </NextLink>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/web/src/components/project-list/trends-scope-picker.tsx
+++ b/apps/web/src/components/project-list/trends-scope-picker.tsx
@@ -1,0 +1,72 @@
+import NextLink from "next/link";
+
+import type { ProjectScope } from "@repo/db/projects";
+
+import type { TrendsProjectSearchUrlBuilder } from "@/app/projects/trends-project-search-state";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const OPTIONS: { scope: ProjectScope; label: string; title: string }[] = [
+  {
+    scope: "all",
+    label: "All projects",
+    title:
+      "Show the full catalog, including deprecated and low-signal projects",
+  },
+  {
+    scope: "active",
+    label: "Active only",
+    title:
+      "Hide deprecated projects, projects with no commit for over a year, and projects gaining under 50 stars a year",
+  },
+];
+
+type Props = {
+  value: ProjectScope;
+  buildPageURL: TrendsProjectSearchUrlBuilder;
+};
+
+/**
+ * Two-state switch over the listing's `scope`. A pair of links rather than a
+ * client component, like `TrendsProjectSortOrderPicker` — the whole listing is
+ * server-rendered, so navigation is what applies the filter.
+ */
+export function TrendsProjectScopePicker({ value, buildPageURL }: Props) {
+  return (
+    // `nav`, not a `role="group"` div: these are links that navigate, and a
+    // labelled landmark is the semantic fit (also what biome's a11y rule wants).
+    // `h-9` matches the sort picker's `Button` (also h-9, border-box), so the
+    // two controls line up; the links stretch to fill it.
+    <nav
+      className="inline-flex h-9 overflow-hidden rounded-md border"
+      aria-label="Which projects to show"
+    >
+      {OPTIONS.map(({ scope, label, title }) => {
+        const isCurrent = scope === value;
+        const url = buildPageURL((state) => ({
+          ...state,
+          scope,
+          // Filtering shrinks the result set: the current page may not exist.
+          page: 1,
+        }));
+        return (
+          <NextLink
+            key={scope}
+            href={url}
+            title={title}
+            aria-current={isCurrent ? "true" : undefined}
+            className={cn(
+              buttonVariants({ variant: "ghost", size: "sm" }),
+              // `h-full` overrides the `sm` size's `h-8` (tailwind-merge keeps
+              // the last height), so each link fills the 36px container.
+              "h-full rounded-none border-0 font-sans",
+              isCurrent && "bg-secondary text-secondary-foreground",
+            )}
+          >
+            {label}
+          </NextLink>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/components/search-palette/search-palette-results.tsx
+++ b/apps/web/src/components/search-palette/search-palette-results.tsx
@@ -160,7 +160,10 @@ export function SearchForTextCommand({
         <SearchIcon className="size-6" />
       </div>
       <div>
-        Search for
+        {/* "all projects": this leaves the palette's quick list — a subset that
+            excludes deprecated and newly added projects — for the full-catalog
+            search on /projects. */}
+        Search all projects for
         <span className="ml-1 font-bold italic">{searchQuery}</span>
       </div>
     </CommandItem>

--- a/apps/web/src/components/search-palette/search-palette.tsx
+++ b/apps/web/src/components/search-palette/search-palette.tsx
@@ -14,7 +14,6 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   CommandDialog,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandList,
@@ -177,7 +176,22 @@ function CombinedSearchResults({
   usePrefetchFirstProject(filteredProjects);
 
   if (isEmptySearchResults) {
-    return <CommandEmpty>No results found.</CommandEmpty>;
+    // No local match is precisely when the full-catalog search is worth
+    // offering, so keep the "Search for ..." entry. It's a plain <div> rather
+    // than `CommandEmpty` on purpose: cmdk renders `Command.Empty` only while
+    // the list holds zero items, and the entry below is an item — it would
+    // hide this message.
+    return (
+      <CommandGroup>
+        <div className="py-6 text-center text-sm">
+          No quick match for <span className="italic">{searchQuery}</span>.
+        </div>
+        <SearchForTextCommand
+          searchQuery={searchQuery}
+          onSelectSearchForText={onSelectSearchForText}
+        />
+      </CommandGroup>
+    );
   }
   return (
     <CommandGroup
@@ -211,12 +225,10 @@ function CombinedSearchResults({
           </React.Fragment>
         );
       })}
-      {!isEmptySearchResults && (
-        <SearchForTextCommand
-          searchQuery={searchQuery}
-          onSelectSearchForText={onSelectSearchForText}
-        />
-      )}
+      <SearchForTextCommand
+        searchQuery={searchQuery}
+        onSelectSearchForText={onSelectSearchForText}
+      />
     </CommandGroup>
   );
 }

--- a/apps/web/tests/e2e/projects.spec.ts
+++ b/apps/web/tests/e2e/projects.spec.ts
@@ -21,7 +21,7 @@ test("go to all projects page", async ({ page }) => {
     .click();
 
   await expect(
-    page.getByRole("heading", { name: "All Projects" })
+    page.getByRole("heading", { name: "Active Projects" })
   ).toBeVisible();
 });
 

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -9,7 +9,7 @@ Two cache tables store pre-computed scores, refreshed daily by the `daily-update
 - **`repo_trends`** (one row per repo): raw star deltas (`daily`, `weekly`, `monthly`, `quarterly`, `yearly`) plus `popularity_score` and `activity_score`
 - **`project_trends`** (one row per project, including deprecated ones): primary package, `monthly_downloads`, `usage_score` and `relevance_score`
 
-The three dimension scores (popularity, activity, usage) serve as **sort keys**. The composite `relevance_score` is only a **quality floor** (`WHERE relevance_score >= 0`), never an `ORDER BY`.
+The three dimension scores (popularity, activity, usage) serve as **sort keys**, and popularity and activity also drive the [UI labels and the `scope` filter](#ui-labels-and-the-scope-filter). The composite `relevance_score` was the listing's quality floor and now has **no consumer** — see below.
 
 The pure functions live in `packages/db/src/repo-trends/scoring.ts` and `packages/db/src/project-trends/scoring.ts`, with unit tests pinning the anchors. Scores are stored, not computed at query time: after changing a formula, re-run the pipeline to see any effect.
 
@@ -29,12 +29,24 @@ Range ~ −100 to +100 (raw +1000/year ≈ 60, +10k/year ≈ 90). Sort key for *
 ## `activity_score` — maintenance
 
 ```
-decay = max(0, 100 - log2(days_since_last_commit + 1) * 10)
-bonus = min(10, log2(contributors) * 3)   when contributors > 1
-score = decay + bonus
+base  = 100 * (1 - log2(days_since_last_commit / 30) / log2(365 / 30))   clamped to [-100, 100]
+bonus = min(10, log2(contributors) * 3)   when contributors > 1 AND base > 0
+score = base + bonus
 ```
 
-Range 0–110. Sort key for **Most active**. Anchors: commit yesterday ≈ 90–100, 1 week ≈ 70, 1 month ≈ 50, 1 year ≈ 15, ~3 years → 0. No commit date → 0 (fully inactive, the "frozen" UI label). The small contributor bonus rewards bus-factor without letting community size dominate recency.
+Range −100…110, mirroring `popularity_score`'s signed shape. Sort key for **Most active**.
+
+| Last commit | ≤30d | 90d | 180d | **1 year** | 2y | 3y | 10y | none |
+|---|---|---|---|---|---|---|---|---|
+| Score | 100 | 56 | 28 | **0** | −28 | −44 | −93 | −100 |
+
+**Why one year is the neutral line:** it is where Best of JS has always drawn "inactive". The static API's `isInactive` rule excluded any project with no commit for over a year from the curated list, and a signed score lets that judgement flow into `relevance_score` and the `scope` filter instead of bottoming out at zero.
+
+**Why the bonus is gated on a positive base:** community size must never soften an inactivity verdict. A 5-contributor repo dead for two years stays at −28 rather than drifting to −18.
+
+**Why no commit date maps to −100, not 0:** under the signed scale, `0` means "a year ago" — mid-range. Returning 0 for missing commit data would quietly promote it to merely-stale.
+
+**Ties under 30 days.** Everything committed within the last month scores 100 (plus the bonus, so contributor count breaks ties there). Exact recency ordering lives in the dedicated **Last commit** sort — the same division of labour `usage_score` has with **Monthly downloads**.
 
 ## `usage_score` — NPM adoption
 
@@ -59,7 +71,7 @@ The original slope (100 at 10M/month) saturated hundreds of popular packages at 
 
 **Not a sort key:** the **Monthly downloads** sort orders by raw `monthly_downloads`. Any log-scale score buckets projects into ties (the listing then degrades to alphabetical order); raw counts give an exact order. The score only feeds the relevance blend, where clamping is harmless.
 
-## `relevance_score` — the quality floor
+## `relevance_score` — currently unused
 
 ```
 with package:    popularity * 0.50 + activity * 0.25 + usage * 0.25
@@ -67,13 +79,39 @@ without package: popularity * 0.65 + activity * 0.35
 deprecated:      minus 17
 ```
 
-Used **only** as `WHERE relevance_score >= 0` in listings — never for ordering. The `/search` route drops the filter so the full catalog (including deprecated, low-signal projects) stays findable.
+**This score has no consumer.** It was the listing's quality floor (`WHERE relevance_score >= 0`) until that floor was removed, and it is now computed and stored daily but read only by the `check-trends-queries` task. Since the activity recalibration, `activity` is signed here too, so inactivity subtracts rather than merely contributing nothing.
 
-**Why the malus is −17:** deprecated repos lose their `repo_trends` row daily (star tracking stops, a cost saving), so their popularity and activity are 0 and only usage can keep them above the floor: `usage * 0.25 − 17 ≥ 0` requires usage ≈ 68, i.e. **~10M downloads/month**. That keeps jquery-class legacy packages visible in listings while hiding deprecated projects with no meaningful adoption. (−17 preserves the ~10M threshold the original −20 malus had under the old usage slope.)
+**Why a weighted sum replaced curation badly.** The static API filtered with a **veto**: over a year without a commit meant excluded, regardless of stars, unless the project was featured, promoted, or above 100k monthly downloads. A weighted sum cannot express that — any dimension compensates for any other, so a project with decent star momentum and no commits for two years still scores positive. That is why the `scope` filter (below) tests the raw signals directly instead of reviving this score.
+
+**Why the malus is −17:** deprecated repos lose their `repo_trends` row daily (star tracking stops, a cost saving), so only usage can lift them: `usage * 0.25 − 17 ≥ 0` requires usage ≈ 68, i.e. **~10M downloads/month**.
+
+## UI labels and the `scope` filter
+
+Labels are derived at render time by `getProjectLabel()` (`packages/db/src/project-trends/labels.ts`) from data already on the row — no stored flags, no extra queries. **At most one badge per project**, first match wins, because the signals overlap heavily: a project untouched for two years has almost always stopped gaining stars too.
+
+| | Condition | Badge |
+|---|---|---|
+| 1 | `projects.status = 'deprecated'` | `deprecated` |
+| 2 | `activity_score < 0` (over a year without a commit) | `inactive` |
+| 3 | `repo_trends.yearly < 50` | `cold` |
+
+Null scores render no badge — they mean "not computed yet" (a project added since the last daily run), never zero.
+
+**Every label is a caution, and that is deliberate.** There is no "trending" badge: the momentum sorts are how you look for hot projects, and an endorsement sharing this channel would weaken the warnings — plus the badge fired on most of page 1 under the default sort while being pure noise on the momentum sorts, where every top row qualifies. Removing it also removed the sort-dependent suppression the badge needed, so `getProjectLabel()` is a pure function of the project alone.
+
+**Why `cold` reads the raw yearly delta rather than `popularity_score`:** stars almost never go *down*, so abandonment shows up as *zero* growth — and `computePopularityScore` returns exactly `0` for that, on the wrong side of any `< 0` test. The 50-stars-a-year threshold is inherited from the static API's `YEARLY_STARS_THRESHOLD`, which gated the curated list for years.
+
+**The `scope` filter** (`findProjectsWithTrends()`'s `scope: "all" | "active"`, the listing's `?scope=` param) hides precisely the rows the first three badges name. It defaults to `"active"`, so a bare `/projects` URL is curated and `?scope=all` opts into the complete catalog — curation that is visible and switchable rather than hidden behind a number. The thresholds are exported from `labels.ts` so the SQL predicate and the badge share them; `check-trends-queries` asserts the two agree.
+
+Its predicate is written as three independent "pass" conditions rather than `NOT (a OR b OR c)`: in SQL's three-valued logic, a project with no `repo_trends` row makes that negation `NULL` and disappears, which would silently hide every newly added project.
+
+The reported total counts what the current filters match, `scope` included — it is a filter like the tag or text query, not a window onto a larger set, so the listing says "23 projects" rather than "23 of 64".
+
+**Browsing is curated; searching is not.** A text `query` forces the scope to `"all"` (`resolveScope()` in `find-with-trends.ts`), and the listing hides the scope picker while a query is active. Someone typing a name wants that one project, and hiding it for being deprecated or unmaintained makes search look broken — the command palette's "Search all projects" fallback exists precisely to reach projects its own index omits, and that index already excludes deprecated ones. The rule lives in the query function so the listing page, the OG image route and `check-trends-queries` cannot disagree about it.
 
 ## Interplay with queries
 
-Because deprecated repos have no `repo_trends` row, the listing query (`findProjectsWithTrends()` in `packages/db`) uses `INNER JOIN project_trends` + `LEFT JOIN repo_trends`, sorts with `NULLS LAST` (trend-less projects sink instead of floating to the top of `DESC` sorts), and falls back to `COALESCE(repo_trends.stars, repos.stars)` for the star count.
+Because deprecated repos have no `repo_trends` row, the listing query (`findProjectsWithTrends()` in `packages/db`) `LEFT JOIN`s both cache tables — `project_trends` too, so projects added since the last daily run are still returned, with null scores — sorts with `NULLS LAST` (trend-less projects sink instead of floating to the top of `DESC` sorts), and falls back to `COALESCE(repo_trends.stars, repos.stars)` for the star count.
 
 | UI label | ORDER BY |
 |---|---|
@@ -103,12 +141,39 @@ these two, like most other sorts, just displayed the star count).
 
 ## How to tune
 
-1. Edit the formulas in `packages/db/src/{repo-trends,project-trends}/scoring.ts` and update the unit tests (`pnpm -F db test`)
-2. Recompute the stored scores: `pnpm -F backend daily-update-trends`
-3. Eyeball the result against real data: `bun run apps/backend/src/cli.ts check-trends-queries --sort trending` (see flags with `--help`; it also verifies the floor / sort-order / tag-filter invariants)
+1. Edit the formulas in `packages/db/src/{repo-trends,project-trends}/scoring.ts`, or the label thresholds in `project-trends/labels.ts`, and update the unit tests (`pnpm -F db test`)
+2. Recompute the stored scores: `pnpm -F backend daily-update-trends`. **Scores are stored, not computed at query time** — until this runs, a formula change has no visible effect anywhere
+3. Eyeball the result against real data: `bun run apps/backend/src/cli.ts check-trends-queries --sort trending` (see flags with `--help`; it also verifies the floor / scope / sort-order / tag-filter invariants)
+
+To judge label thresholds across the whole catalog rather than 30 rows in a browser:
+
+```bash
+pnpm -F backend check-trends-queries --tags state --scope all --limit 64 \
+  --columns rank,slug,status,popularity,activity,lastCommit,yearly,label
+```
 
 ## Decision log
 
+- **2026-07-26** — **Recalibrated `activity_score` to a signed scale** (1 year = 0, ≤30 days = 100,
+  negative beyond, no commit date = −100) and rebuilt the UI labels around it. Three findings drove
+  this. (1) The old `frozen` label (`activity_score === 0`) was **unreachable**: the score returned
+  `decay + bonus` with an unconditional contributor bonus, so any repo with ≥2 contributors scored ≥3
+  forever. (2) The old `cold` label (`popularity_score < 0`) tested the wrong side of the boundary —
+  stars rarely fall, so abandonment reads as *zero* growth, which `computePopularityScore` returns
+  exactly. `retalk` (no stars in 12 months, last commit 2 years ago) escaped both labels *and* the old
+  relevance floor, which scored it **+7**. (3) The static API filtered with veto rules, not a score,
+  which no weighted sum can reproduce.
+  Consequences: labels became **one badge per row** by precedence (`deprecated` → `inactive` →
+  `cold`) since the signals correlate; `frozen` became `inactive` at a reachable threshold; `cold`
+  reads the raw yearly delta; and the `scope` filter was added so the curation the badges describe is
+  also actionable. The contributor bonus is now gated on a positive base so community size cannot
+  soften an inactivity verdict.
+  Two labels from the original spec were dropped. **`widely used but unmaintained`** had no user
+  story behind it, and adoption is already legible from rank and star count. **`trending`** (user
+  story 12) was dropped because the momentum sorts already answer "what's hot" — the badge was noise
+  on those sorts, where every top row qualifies, and near-ubiquitous on page 1 of the default sort. It
+  also made every badge a caution, which is a stronger signal, and let `getProjectLabel()` go back to
+  being a pure function of the project (no `sort` input, no suppression list).
 - **2026-07-20** — Restored the remaining pre-migration sort keys dropped by the initial DB
   migration: **Monthly downloads** (renamed back from `"most-used"` — same underlying data, just the
   literal old key, matching the `daily` rename below), and **Last commit** / **Contributors** /

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -5,6 +5,8 @@ export const PROJECT_STATUSES = [
   "deprecated",
 ] as const;
 
+export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
+
 export const TAGS_EXCLUDED_FROM_RANKINGS = [
   "meta",
   "learning",

--- a/packages/db/src/project-trends/index.ts
+++ b/packages/db/src/project-trends/index.ts
@@ -1,1 +1,2 @@
+export * from "./labels";
 export * from "./scoring";

--- a/packages/db/src/project-trends/labels.test.ts
+++ b/packages/db/src/project-trends/labels.test.ts
@@ -1,0 +1,67 @@
+import { getProjectLabel } from "./labels";
+import { describe, expect, test } from "bun:test";
+
+/** A healthy project: recent commits, real star growth, nothing to flag. */
+const healthy = {
+  status: "active" as const,
+  activityScore: 100,
+  yearlyStars: 500,
+};
+
+describe("getProjectLabel", () => {
+  test("a healthy project gets no label", () => {
+    expect(getProjectLabel(healthy)).toBeNull();
+  });
+
+  test("deprecated wins over every computed signal", () => {
+    expect(
+      getProjectLabel({
+        ...healthy,
+        status: "deprecated",
+        activityScore: -50,
+        yearlyStars: 0,
+      }),
+    ).toBe("deprecated");
+  });
+
+  test("negative activity (over a year without a commit) → inactive", () => {
+    expect(getProjectLabel({ ...healthy, activityScore: -28 })).toBe(
+      "inactive",
+    );
+  });
+
+  test("inactive outranks cold", () => {
+    expect(
+      getProjectLabel({ ...healthy, activityScore: -28, yearlyStars: 0 }),
+    ).toBe("inactive");
+  });
+
+  test("fewer than 50 new stars in a year → cold", () => {
+    expect(getProjectLabel({ ...healthy, yearlyStars: 49 })).toBe("cold");
+    expect(getProjectLabel({ ...healthy, yearlyStars: 50 })).toBeNull();
+  });
+
+  test("retalk: no stars in a year, last commit 2 years ago → inactive", () => {
+    expect(
+      getProjectLabel({
+        status: "active",
+        activityScore: -28,
+        yearlyStars: 0,
+      }),
+    ).toBe("inactive");
+  });
+
+  test("null scores produce no label", () => {
+    expect(
+      getProjectLabel({
+        status: "active",
+        activityScore: null,
+        yearlyStars: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("a project tracked under a year is not cold (no yearly delta yet)", () => {
+    expect(getProjectLabel({ ...healthy, yearlyStars: undefined })).toBeNull();
+  });
+});

--- a/packages/db/src/project-trends/labels.ts
+++ b/packages/db/src/project-trends/labels.ts
@@ -1,0 +1,72 @@
+import type { ProjectStatus } from "../constants";
+
+/**
+ * The render-time warning a project carries in listings. **At most one** — the
+ * signals overlap heavily (a project with no commits for two years has almost
+ * always stopped gaining stars too), so a row shows only its most consequential
+ * fact and the rest stays in the sort orders and the metrics column.
+ *
+ * Every label is a caution. Positive momentum deliberately has no badge: the
+ * momentum sorts ("Trending", "Daily"…) are how you look for hot projects, and
+ * mixing an endorsement into this channel would weaken the warnings.
+ *
+ * Returns a key, not display copy — the web app owns the wording and the colour
+ * (`apps/web/src/components/core/project-labels.tsx`).
+ */
+export const PROJECT_LABEL_KEYS = ["deprecated", "inactive", "cold"] as const;
+
+export type ProjectLabelKey = (typeof PROJECT_LABEL_KEYS)[number];
+
+export type ProjectLabelInput = {
+  status: ProjectStatus;
+  /** Signed: negative means more than a year since the last commit. */
+  activityScore: number | null;
+  /** Raw star delta over the past year (`repo_trends.yearly`). */
+  yearlyStars: number | null | undefined;
+};
+
+/**
+ * Fewer than 50 new stars in a year. Inherited from the static API builder's
+ * `YEARLY_STARS_THRESHOLD`, which gated the curated list for years. Read from
+ * the raw delta rather than `popularity_score`, because a project with zero
+ * growth scores exactly 0 there — on the wrong side of any `< 0` test.
+ *
+ * Exported because `findProjectsWithTrends()`'s `scope: "active"` filter hides
+ * exactly the rows this labels: the rule is expressed twice (here in TS, there
+ * in SQL), so the threshold itself must have a single home.
+ */
+export const COLD_YEARLY_STARS = 50;
+/** The neutral line of the signed `activity_score`: one year without a commit. */
+export const INACTIVE_ACTIVITY_SCORE = 0;
+
+export function getProjectLabel({
+  status,
+  activityScore,
+  yearlyStars,
+}: ProjectLabelInput): ProjectLabelKey | null {
+  // Curation beats every computed signal.
+  if (status === "deprecated") return "deprecated";
+
+  // Signed activity: < 0 means over a year without a commit, the line Best of
+  // JS has always drawn. Ranked above `cold` because "has anyone touched this?"
+  // decides adoption, while star momentum is a lagging proxy for the same thing.
+  if (isScore(activityScore) && activityScore < INACTIVE_ACTIVITY_SCORE) {
+    return "inactive";
+  }
+
+  if (typeof yearlyStars === "number" && yearlyStars < COLD_YEARLY_STARS) {
+    return "cold";
+  }
+
+  return null;
+}
+
+/**
+ * Null scores mean "not computed yet" — a project added since the last daily
+ * run, surfaced by the LEFT JOIN in `findProjectsWithTrends()`. Never zero, and
+ * never a reason to label anything: `null < 0` is `false`, but relying on that
+ * coercion is how brand-new projects end up branded inactive.
+ */
+function isScore(value: number | null): value is number {
+  return typeof value === "number";
+}

--- a/packages/db/src/project-trends/scoring.ts
+++ b/packages/db/src/project-trends/scoring.ts
@@ -25,6 +25,12 @@ export function computeUsageScore(monthlyDownloads: number | null | undefined) {
  *
  *   with package:    0.50 * popularity + 0.25 * activity + 0.25 * usage
  *   no package:      0.65 * popularity + 0.35 * activity
+ *
+ * `activity` is signed since the 1-year recalibration (see
+ * `computeActivityScore`), so inactivity now subtracts here instead of merely
+ * contributing nothing. Note this score has had no consumer since the listing's
+ * relevance floor was removed — it is computed and stored, read only by the
+ * `check-trends-queries` task.
  *   minus 17 if deprecated — calibrated so a deprecated project needs
  *   usage ≥ 68 (~10M monthly downloads) to stay above the `>= 0` floor.
  */

--- a/packages/db/src/projects/find-with-trends.ts
+++ b/packages/db/src/projects/find-with-trends.ts
@@ -1,6 +1,20 @@
-import { and, count, eq, gte, type SQL, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  gte,
+  isNull,
+  ne,
+  or,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 
 import type { DB } from "../index";
+import {
+  COLD_YEARLY_STARS,
+  INACTIVE_ACTIVITY_SCORE,
+} from "../project-trends/labels";
 import * as schema from "../schema";
 import type { TrendsSortKey } from "../shared-schemas";
 import { getWhereClauseSearchByTag, getWhereClauseSearchByText } from "./find";
@@ -32,12 +46,64 @@ const sortExpressionByKey: Record<TrendsSortKey, SQL> = {
   newest: sql`${projects.createdAt}`,
 };
 
+/**
+ * `"active"` hides every project the UI would badge as a warning — deprecated,
+ * inactive (over a year without a commit) or cold (under 50 new stars in a
+ * year). It is the honest, switchable successor to the old static API's veto
+ * rules, and the default: `"all"` opts into the complete catalog.
+ *
+ * **A text `query` overrides this to `"all"`** — see `resolveScope()`.
+ */
+export type ProjectScope = "all" | "active";
+
+/**
+ * Browsing is curated; searching is not. Someone typing a name is looking for
+ * one specific project, and hiding it because it is deprecated or unmaintained
+ * makes the search look broken — the palette's "Search all projects" fallback
+ * exists precisely to reach those projects, and its own index already excludes
+ * deprecated ones.
+ *
+ * The rule lives here rather than in each caller so the listing page, the OG
+ * image route and the `check-trends-queries` task cannot disagree about it.
+ */
+export function resolveScope(
+  scope: ProjectScope,
+  query?: string,
+): ProjectScope {
+  return query ? "all" : scope;
+}
+
+/**
+ * Keeps only projects with no warning badge. Written as three independent
+ * "pass" conditions rather than `NOT (a OR b OR c)` on purpose: in SQL's
+ * three-valued logic, a project with no `repo_trends` row yet (added since the
+ * last daily run) makes that negation `NULL` and vanishes from the listing.
+ * Null scores mean "not computed yet", which is not a reason to hide anything —
+ * the same rule `getProjectLabel()` follows when it renders no badge.
+ */
+export function getWhereClauseActiveScope() {
+  return and(
+    ne(projects.status, "deprecated"),
+    or(
+      isNull(repoTrends.activityScore),
+      gte(repoTrends.activityScore, INACTIVE_ACTIVITY_SCORE),
+    ),
+    or(isNull(repoTrends.yearly), gte(repoTrends.yearly, COLD_YEARLY_STARS)),
+  );
+}
+
 export interface FindProjectsWithTrendsOptions {
   db: DB;
   limit?: number;
   page?: number;
   /** Text search on project name/description and repo owner/name */
   query?: string;
+  /**
+   * Quality view: `"active"` (default) hides badged projects, `"all"` shows
+   * everything. Ignored when `query` is set — text search always searches the
+   * whole catalog.
+   */
+  scope?: ProjectScope;
   /**
    * Quality floor: keep only projects with `relevance_score >= 0`.
    * Off by default — the public listing/search shows the full catalog
@@ -68,16 +134,25 @@ export async function findProjectsWithTrends({
   page = 1,
   query,
   relevanceFloor = false,
+  scope = "active",
   sort = "most-stars",
   tagCodes,
 }: FindProjectsWithTrendsOptions) {
   const offset = (page - 1) * limit;
 
-  const where = and(
+  // Everything except the scope filter, so the unfiltered total can reuse it.
+  const baseWhere = and(
     relevanceFloor ? gte(projectTrends.relevanceScore, 0) : undefined,
     query ? getWhereClauseSearchByText(query) : undefined,
     tagCodes && tagCodes.length > 0
       ? getWhereClauseSearchByTag(db, tagCodes)
+      : undefined,
+  );
+
+  const where = and(
+    baseWhere,
+    resolveScope(scope, query) === "active"
+      ? getWhereClauseActiveScope()
       : undefined,
   );
 
@@ -141,6 +216,8 @@ export async function findProjectsWithTrends({
     totalQuery,
   ]);
 
+  // `total` counts what the current filters match, `scope` included — it is a
+  // filter like `tagCodes` or `query`, not a window onto a larger set.
   return { projects: foundProjects, total: totalResults[0].count };
 }
 

--- a/packages/db/src/repo-trends/scoring.test.ts
+++ b/packages/db/src/repo-trends/scoring.test.ts
@@ -109,33 +109,72 @@ describe("computeActivityScore", () => {
     expect(score).toBeLessThanOrEqual(110);
   });
 
-  test("commit 2 weeks ago → ~60-70", () => {
+  test("anchor: within 30 days → the full 100 (plus contributor bonus)", () => {
     const score = computeActivityScore({
       lastCommit: daysAgo(14),
       contributors: 5,
       now,
     });
-    expect(score).toBeGreaterThan(60);
-    expect(score).toBeLessThan(75);
+    expect(score).toBeGreaterThanOrEqual(100);
+    expect(score).toBeLessThanOrEqual(110);
   });
 
-  test("commit 1 year ago → low (<25)", () => {
+  test("anchor: 90 days → ~56, 180 days → ~28", () => {
+    const contributors = 1; // isolate the base from the bonus
+    expect(
+      computeActivityScore({ lastCommit: daysAgo(90), contributors, now }),
+    ).toBeCloseTo(56, 0);
+    expect(
+      computeActivityScore({ lastCommit: daysAgo(180), contributors, now }),
+    ).toBeCloseTo(28, 0);
+  });
+
+  test("anchor: 1 year is the neutral line → 0", () => {
+    expect(
+      computeActivityScore({ lastCommit: daysAgo(365), contributors: 3, now }),
+    ).toBeCloseTo(0, 1);
+  });
+
+  test("beyond a year the score goes negative: 2y → ~-28, 3y → ~-44", () => {
+    expect(
+      computeActivityScore({ lastCommit: daysAgo(730), contributors: 3, now }),
+    ).toBeCloseTo(-28, 0);
+    expect(
+      computeActivityScore({ lastCommit: daysAgo(1095), contributors: 3, now }),
+    ).toBeCloseTo(-44, 0);
+  });
+
+  test("the contributor bonus never softens an inactivity verdict", () => {
+    const solo = computeActivityScore({
+      lastCommit: daysAgo(730),
+      contributors: 1,
+      now,
+    });
+    const crowded = computeActivityScore({
+      lastCommit: daysAgo(730),
+      contributors: 500,
+      now,
+    });
+    expect(crowded).toBe(solo);
+    expect(crowded).toBeLessThan(0);
+  });
+
+  test("no commit date → the floor, not 0 (0 now means 'a year ago')", () => {
+    expect(
+      computeActivityScore({ lastCommit: null, contributors: 5, now }),
+    ).toBe(-100);
+    expect(
+      computeActivityScore({ lastCommit: undefined, contributors: 5, now }),
+    ).toBe(-100);
+  });
+
+  test("clamps at the -100 floor for very old commits", () => {
     const score = computeActivityScore({
-      lastCommit: daysAgo(365),
+      lastCommit: daysAgo(365 * 30),
       contributors: 3,
       now,
     });
-    expect(score).toBeGreaterThan(0);
-    expect(score).toBeLessThan(25);
-  });
-
-  test("no commit date → 0", () => {
-    expect(
-      computeActivityScore({ lastCommit: null, contributors: 5, now }),
-    ).toBe(0);
-    expect(
-      computeActivityScore({ lastCommit: undefined, contributors: 5, now }),
-    ).toBe(0);
+    expect(score).toBe(-100);
   });
 
   test("recent activity ranks above stale activity", () => {
@@ -152,7 +191,7 @@ describe("computeActivityScore", () => {
     expect(recent).toBeGreaterThan(stale);
   });
 
-  test("contributor bonus capped at 10", () => {
+  test("contributor bonus capped at 10 (only where the base is positive)", () => {
     const fewContributors = computeActivityScore({
       lastCommit: daysAgo(1),
       contributors: 2,

--- a/packages/db/src/repo-trends/scoring.ts
+++ b/packages/db/src/repo-trends/scoring.ts
@@ -38,28 +38,58 @@ type ActivityInputs = {
   now?: Date;
 };
 
+/** Committed within a month → the full 100. */
+const FULL_SCORE_DAYS = 30;
+/** A year without a commit is the neutral line: score 0, negative beyond. */
+const ZERO_SCORE_DAYS = 365;
+const LOG_SPAN = Math.log2(ZERO_SCORE_DAYS / FULL_SCORE_DAYS); // ≈ 3.6
+const MIN_SCORE = -100;
+
 /**
- * Log2 decay from days-since-last-commit, plus a small contributor bonus.
+ * Signed log2 decay from days-since-last-commit, plus a small contributor
+ * bonus. Range −100…110, mirroring `popularity_score`'s signed shape.
  *
- * decay = max(0, 100 - log2(days+1) * 10)
- * bonus = min(10, log2(contributors) * 3) when contributors > 1, else 0
+ * base  = 100 * (1 - log2(days / 30) / log2(365 / 30)), clamped to [-100, 100]
+ * bonus = min(10, log2(contributors) * 3) when contributors > 1 AND base > 0
  *
- * No commit date → score 0 (treat as fully inactive).
+ * Anchors: ≤30d → 100, 90d → 56, 180d → 28, **1y → 0**, 2y → −28, 3y → −44,
+ * 10y → −93. One year is the neutral line because that is where Best of JS has
+ * always drawn "inactive" (the static API's `isInactive` rule excluded projects
+ * with no commit for over a year), and a signed score lets that judgement carry
+ * into `relevance_score` instead of bottoming out at 0.
+ *
+ * The bonus is gated on a positive base so community size can never soften an
+ * inactivity verdict: a 5-contributor repo dead for 2 years stays at −28.
+ *
+ * No commit date → `MIN_SCORE`. It must not be 0, which now reads as "a year
+ * ago" rather than "worst possible".
+ *
+ * Everything committed within the last 30 days ties at 100 (+ bonus, so the
+ * contributor count breaks ties there). Exact recency ordering lives in the
+ * dedicated "Last commit" sort, the same split `usage_score` has with the
+ * "Monthly downloads" sort.
  */
 export function computeActivityScore(inputs: ActivityInputs): number {
   const { lastCommit, contributors, now = new Date() } = inputs;
-  if (!lastCommit) return 0;
+  if (!lastCommit) return MIN_SCORE;
 
   const days = Math.max(
     0,
     (now.getTime() - lastCommit.getTime()) / (1000 * 60 * 60 * 24),
   );
-  const decay = Math.max(0, 100 - Math.log2(days + 1) * 10);
+
+  const base =
+    days <= FULL_SCORE_DAYS
+      ? 100
+      : Math.max(
+          MIN_SCORE,
+          100 * (1 - Math.log2(days / FULL_SCORE_DAYS) / LOG_SPAN),
+        );
 
   const bonus =
-    contributors && contributors > 1
+    base > 0 && contributors && contributors > 1
       ? Math.min(10, Math.log2(contributors) * 3)
       : 0;
 
-  return decay + bonus;
+  return base + bonus;
 }

--- a/packages/db/src/tags/find-relevant.ts
+++ b/packages/db/src/tags/find-relevant.ts
@@ -5,9 +5,15 @@ import {
   getWhereClauseSearchByTag,
   getWhereClauseSearchByText,
 } from "../projects/find";
+import {
+  getWhereClauseActiveScope,
+  type ProjectScope,
+  resolveScope,
+} from "../projects/find-with-trends";
 import * as schema from "../schema";
 
-const { projects, projectTrends, projectsToTags, repos, tags } = schema;
+const { projects, projectTrends, projectsToTags, repoTrends, repos, tags } =
+  schema;
 
 export interface FindRelevantTagsOptions {
   db: DB;
@@ -17,6 +23,11 @@ export interface FindRelevantTagsOptions {
   query?: string;
   /** Quality floor matching findProjectsWithTrends()'s default (off — full catalog); enable to hide low-signal projects */
   relevanceFloor?: boolean;
+  /**
+   * Must match the listing's scope. A suggestion derived from projects the
+   * listing filters out is a dead end: the chip leads to "No projects found".
+   */
+  scope?: ProjectScope;
   limit?: number;
 }
 
@@ -36,10 +47,16 @@ export async function findRelevantTags({
   tagCodes,
   query,
   relevanceFloor = false,
+  scope = "active",
   limit = 20,
 }: FindRelevantTagsOptions): Promise<RelevantTag[]> {
   const where = and(
     relevanceFloor ? gte(projectTrends.relevanceScore, 0) : undefined,
+    // Same predicate and the same query-wins rule as the listing, imported
+    // rather than restated so the two cannot drift.
+    resolveScope(scope, query) === "active"
+      ? getWhereClauseActiveScope()
+      : undefined,
     query ? getWhereClauseSearchByText(query) : undefined,
     tagCodes && tagCodes.length > 0
       ? getWhereClauseSearchByTag(db, tagCodes)
@@ -49,20 +66,25 @@ export async function findRelevantTags({
       : undefined,
   );
 
-  return db
-    .select({
-      code: tags.code,
-      name: tags.name,
-      description: tags.description,
-      count: count(projectsToTags.projectId),
-    })
-    .from(tags)
-    .innerJoin(projectsToTags, eq(projectsToTags.tagId, tags.id))
-    .innerJoin(projects, eq(projects.id, projectsToTags.projectId))
-    .leftJoin(projectTrends, eq(projectTrends.projectId, projects.id))
-    .innerJoin(repos, eq(projects.repoId, repos.id))
-    .where(where)
-    .groupBy(tags.id)
-    .orderBy(desc(count(projectsToTags.projectId)))
-    .limit(limit);
+  return (
+    db
+      .select({
+        code: tags.code,
+        name: tags.name,
+        description: tags.description,
+        count: count(projectsToTags.projectId),
+      })
+      .from(tags)
+      .innerJoin(projectsToTags, eq(projectsToTags.tagId, tags.id))
+      .innerJoin(projects, eq(projects.id, projectsToTags.projectId))
+      .leftJoin(projectTrends, eq(projectTrends.projectId, projects.id))
+      .innerJoin(repos, eq(projects.repoId, repos.id))
+      // LEFT, like the listing: deprecated repos have no row, and neither do
+      // projects added since the last daily run.
+      .leftJoin(repoTrends, eq(repoTrends.repoId, repos.id))
+      .where(where)
+      .groupBy(tags.id)
+      .orderBy(desc(count(projectsToTags.projectId)))
+      .limit(limit)
+  );
 }


### PR DESCRIPTION
## Goal

Closes #428.

Since #426 removed the relevance floor, `/projects` shows the full catalog — including deprecated and unmaintained projects — with **no signal at all**. The `state` tag went from 38 to 64 entries. This PR makes the low-quality rows visible, and then makes that curation actionable.

## Concepts introduced

**Badges** — at most one per row, first match wins. All three are cautions; the signals correlate too strongly for stacking them to add information (a project untouched for two years has almost always stopped gaining stars too).

| Badge | Rule |
|---|---|
| `deprecated` | `projects.status` — curated, beats every computed signal |
| `inactive` | `activity_score < 0` — over a year without a commit |
| `cold` | `repo_trends.yearly < 50` — under 50 new stars in a year |

**Scope** — `?scope=all` \| `active`, defaulting to **`active`**. "Active only" hides exactly the badged rows, so the badge legend *is* the filter definition. A bare `/projects` URL is curated; the full catalog is one visible click away. This is the honest successor to the static API's old veto rules — same effect, but switchable instead of hidden behind a number.

A **text query always searches everything** (`resolveScope()`): someone typing a name wants that project, deprecated or not.

## Decisions worth flagging

- **`activity_score` recalibrated to a signed scale**: ≤30d → 100, **1 year → 0**, 2y → −28, 10y → −93, no commit date → −100. One year is where Best of JS has always drawn "inactive". ⚠️ **Requires `pnpm -F backend daily-update-trends`** — scores are stored, so no `inactive` badge appears until then.
- Two labels from #428's spec were **dropped**. `trending` (the momentum sorts already answer "what's hot", and it was noise there / near-ubiquitous on page 1) and `widely used but unmaintained` (no user story; adoption is already legible from rank and star count). Removing `trending` also let `getProjectLabel()` stay a pure function of the project.
- `frozen` → `inactive`. The original `activity_score === 0` test was **unreachable**: the contributor bonus was unconditional, so any repo with ≥2 contributors scored ≥3 forever.
- `cold` reads the **raw yearly delta**, not `popularity_score`. Stars rarely fall, so abandonment scores exactly `0` — the wrong side of a `< 0` test. `retalk` (no stars in a year, last commit 2 years ago) escaped both old labels *and* the old floor, which scored it **+7**. The 50-star threshold is the static API's own `YEARLY_STARS_THRESHOLD`.
- The threshold constants live in `labels.ts` and are imported by the SQL predicate, so the badge rule and the filter can't drift; `check-trends-queries` asserts they agree.
- **Fixed `--color-destructive`**: it wrapped an `oklch()` value in `hsl()`, so every `bg-destructive` computed to transparent. Side effect — the GPL badge on detail pages is red for the first time.

## What changes in the UI

- **Listing rows**: badge after the project name (wrapping row). Deprecated rows are de-emphasised — grayscale logo, muted name/description/metrics — with the badge left at full strength.
- **Listing header**: `All projects | Active only` split button beside the sort picker. Hidden while searching, where it would be inert.
- **Project detail page**: `deprecated` badge next to the project name, so someone arriving from a shared link sees the one thing the charts can't tell them.
- **Command palette**: the "Search all projects for X" fallback now appears on zero results — it was unreachable in exactly the case it exists for — and says "all projects" to distinguish the quick local list from the full catalog.
- **Related-tag chips** honour the scope, so a suggestion can't lead to an empty listing.

## How to test

```bash
pnpm -F backend daily-update-trends     # required first — scores are stored
pnpm -F backend check-trends-queries --tags state --scope all --limit 64 \
  --columns rank,slug,status,popularity,activity,lastCommit,yearly,label
pnpm -F backend check-trends-queries --tags state --scope active   # ~38, "All invariants hold"
```

Then on the preview:

- `/projects?tags=state` — filtered by default; `&scope=all` restores the full list with badges
- a deprecated project's muted row, and its detail page badge
- palette: `zzzqqq` → "Search all projects for zzzqqq" → lands on results, not an empty page

## Screenshots

Check `State management` tag

<img width="1204" height="851" alt="image" src="https://github.com/user-attachments/assets/8ec1c4b7-5b5f-4d27-b971-05805d4240a0" />

<img width="1162" height="944" alt="image" src="https://github.com/user-attachments/assets/c5c68a04-1867-48b0-939d-de75d38dd269" />


